### PR TITLE
feat: integrate Portless for stable .localhost dev URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ This is a Slidev addon that enables displaying BPMN 2.0 diagrams in presentation
 ## Development Commands
 
 ```bash
-# Run the example presentation in dev mode
+# Run the example presentation in dev mode (requires git and `npm install -g portless`)
+# Dev server URL is branch-based, e.g. http://slidev-addon-bpmn-main.localhost:1355
 npm run dev
 
 # Build the example presentation

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Display BPMN 2.0 diagrams in Slidev presentations",
   "type": "module",
   "scripts": {
-    "dev": "slidev example.md",
+    "dev": "portless run sh -c 'npx slidev example.md --port $PORT --remote --bind 127.0.0.1'",
     "build": "slidev build example.md",
     "export": "slidev export example.md",
     "screenshot": "slidev export example.md --format png"
@@ -36,7 +36,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "repository": {
     "type": "git",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  server: {
+    allowedHosts: ['.localhost'],
+  },
   optimizeDeps: {
     include: [
       'bpmn-js/lib/Viewer',


### PR DESCRIPTION
## Summary
- Replace plain `slidev` dev command with Portless for branch-based deterministic `.localhost` URLs
- Bump Node.js engine requirement to `>=20` (Portless requirement)
- Update CLAUDE.md with Portless prerequisites

## Test plan
- [x] Install Portless globally: `npm install -g portless`
- [x] Run `npm run dev` and verify dev server is accessible at `http://slidev-addon-bpmn-<branch>.localhost:1355`
- [x] Confirm BPMN diagram renders correctly on the example slide

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)