### PR TITLE
chore: set dependabot npm schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
     assignees:


### PR DESCRIPTION
## Summary
- Changes the npm Dependabot check interval from weekly to daily

## Test plan
- [ ] Verify Dependabot runs daily after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)