### PR TITLE
feat: add interactive BpmnModeler component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,17 @@ npm run screenshot
 
 ## Architecture
 
-### Core Component
+### Components
 
-The addon consists of a single Vue component at `components/Bpmn.vue` that:
+The addon provides three Vue components:
+
+- **`Bpmn.vue`** — Static SVG rendering (off-screen render approach, best for PDF exports)
+- **`BpmnTokenSimulation.vue`** — Interactive viewer with animated token flow simulation
+- **`BpmnModeler.vue`** — Interactive BPMN modeler for live diagram editing (workshops/trainings)
+
+#### Bpmn.vue (Static Viewer)
+
+The `Bpmn.vue` component at `components/Bpmn.vue`:
 
 1. **Fetches BPMN XML**: Loads `.bpmn` files from the `public/` folder via fetch
 2. **Renders using bpmn-js**: Creates an off-screen DOM container (1920x1080) to render the diagram
@@ -48,7 +56,8 @@ The `vite.config.ts` file is **critical** for this addon to work. It includes bp
 ## Package Distribution
 
 The npm package includes only:
-- `components/` directory (the Bpmn.vue component)
+- `components/` directory (Bpmn.vue, BpmnTokenSimulation.vue, BpmnModeler.vue)
+- `composables/` directory (useBpmn.ts)
 - `vite.config.ts` (required Vite configuration)
 
 Everything else (`example.md`, `public/`, `docs/`) is excluded via the `files` field in package.json.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ Or in your `package.json`:
 
 ## 🧩 Components
 
-This addon provides two complementary components for different use cases:
+This addon provides three complementary components for different use cases:
 
 - **`<Bpmn>`** - Static BPMN rendering for PDFs, presentations, and documentation
 - **`<BpmnTokenSimulation>`** - Interactive token-based process simulation for live demos
+- **`<BpmnModeler>`** - Interactive BPMN modeler for live diagram editing during workshops and trainings
 
 ## 🔧 Component Reference
 
@@ -95,6 +96,32 @@ Renders interactive BPMN diagrams with token simulation capabilities. Perfect fo
 | `height` | `string` | `'auto'` | Height of the diagram container (defaults to 500px when 'auto') |
 
 The token simulation provides interactive controls for stepping through process execution with animated token flow.
+
+### BpmnModeler Component
+
+Embeds an interactive BPMN modeler for live diagram editing. Ideal for workshops, trainings, and collaborative sessions where you build diagrams step by step.
+
+```vue
+<BpmnModeler
+  bpmnFilePath="./my-process.bpmn"
+  width="100%"
+  height="500px"
+/>
+```
+
+Or start with a blank canvas (a single start event):
+
+```vue
+<BpmnModeler height="500px" />
+```
+
+**Props:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `bpmnFilePath` | `string` | — | Optional path to a `.bpmn` file (relative to `public/`). Omit for a blank diagram. |
+| `width` | `string` | `'100%'` | Width of the modeler container |
+| `height` | `string` | `'500px'` | Height of the modeler container |
 
 ## 💡 Tips
 

--- a/components/BpmnModeler.vue
+++ b/components/BpmnModeler.vue
@@ -1,22 +1,99 @@
 <template>
-  <div :style="{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: containerHeight }">
-    <p v-if="loading">Loading BPMN modeler...</p>
+  <div :style="{ position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: containerHeight }">
+    <p v-if="loading">Loading BPMN diagram...</p>
     <p v-if="error" class="text-red-500">{{ error }}</p>
-    <div ref="containerRef" :style="{
-    width: `calc(${props.width} - ${margin * 2}px)`,
-    height: `calc(${containerHeight} - ${margin * 2}px)`,
-    margin: `${margin}px`,
-  }"
-    ></div>
+
+    <div ref="viewerContainerRef" :style="{
+      width: `calc(${props.width} - ${margin * 2}px)`,
+      height: `calc(${containerHeight} - ${margin * 2}px)`,
+      margin: `${margin}px`,
+    }"></div>
+
+    <button
+      v-if="!loading && !error"
+      :style="{
+        position: 'absolute',
+        top: '12px',
+        right: '12px',
+        zIndex: 10,
+        cursor: 'pointer',
+        background: 'white',
+        border: '1px solid #ccc',
+        borderRadius: '4px',
+        padding: '6px 8px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        fontSize: '13px',
+        color: '#333',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+      }"
+      title="Open modeler"
+      @click="openFullscreen"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+      </svg>
+      Edit
+    </button>
+
+    <Teleport to="body">
+      <div
+        v-if="isFullscreen"
+        :style="{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100vw',
+          height: '100vh',
+          zIndex: 9999,
+          background: 'white',
+        }"
+        @keydown.stop
+      >
+        <div ref="modelerContainerRef" :style="{ width: '100%', height: '100%' }"></div>
+
+        <button
+          :style="{
+            position: 'absolute',
+            top: '16px',
+            right: '16px',
+            zIndex: 10000,
+            cursor: 'pointer',
+            background: 'white',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            padding: '6px 8px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+            fontSize: '13px',
+            color: '#333',
+            boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+          }"
+          title="Close modeler"
+          @click="closeFullscreen"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"/>
+            <line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+          Close
+        </button>
+      </div>
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
 
-import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { type Ref, nextTick, onMounted, onUnmounted, ref } from 'vue'
+import BpmnViewer from 'bpmn-js/lib/Viewer'
 import BpmnModeler from 'bpmn-js/lib/Modeler'
 import 'bpmn-js/dist/assets/bpmn-js.css'
 import 'bpmn-js/dist/assets/diagram-js.css'
+import 'bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css'
 import { onSlideEnter } from '@slidev/client'
 import { useBpmn } from '../composables/useBpmn'
 
@@ -24,9 +101,14 @@ const margin = 5
 const containerWaitTimeout = 5000
 
 const { loading, error, fetchBpmnXml, withLoading } = useBpmn()
-const containerRef = ref<HTMLDivElement | null>(null)
+const viewerContainerRef = ref<HTMLDivElement | null>(null)
+const modelerContainerRef = ref<HTMLDivElement | null>(null)
 const isRendered = ref(false)
+const isFullscreen = ref(false)
+const currentXml = ref<string | null>(null)
+let viewer: InstanceType<typeof BpmnViewer> | null = null
 let modeler: InstanceType<typeof BpmnModeler> | null = null
+let hasModelerChanges = false
 
 const props = withDefaults(defineProps<{
   bpmnFilePath?: string
@@ -39,11 +121,7 @@ const props = withDefaults(defineProps<{
 
 const containerHeight = props.height
 
-/**
- * Polls for container dimensions to be ready before rendering.
- * Prevents "non-finite" SVG matrix errors when canvas.zoom() is called.
- */
-async function waitForContainer(): Promise<void> {
+async function waitForContainer(containerRef: Ref<HTMLDivElement | null>): Promise<void> {
   return new Promise((resolve, reject) => {
     const start = Date.now()
     const checkDimensions = () => {
@@ -59,33 +137,43 @@ async function waitForContainer(): Promise<void> {
   })
 }
 
-/**
- * Renders the BPMN modeler.
- * Includes duplicate prevention since Slidev calls both onMounted and onSlideEnter.
- */
-async function renderBpmn() {
+async function renderViewer() {
+  if (viewer) {
+    viewer.destroy()
+    viewer = null
+  }
 
-  // Prevent duplicate rendering
+  await waitForContainer(viewerContainerRef)
+
+  viewer = new BpmnViewer({ container: viewerContainerRef.value! })
+
+  if (!currentXml.value) {
+    if (props.bpmnFilePath) {
+      currentXml.value = await fetchBpmnXml(props.bpmnFilePath)
+    } else {
+      const tempModeler = new BpmnModeler({ container: document.createElement('div') })
+      await tempModeler.createDiagram()
+      const { xml } = await tempModeler.saveXML({ format: true })
+      tempModeler.destroy()
+      if (xml) currentXml.value = xml
+    }
+  }
+
+  if (currentXml.value) {
+    await viewer.importXML(currentXml.value)
+    const canvas = viewer.get('canvas') as any
+    canvas.resized()
+    canvas.zoom('fit-viewport', 'auto')
+    canvas.zoom(Math.min(canvas.zoom() * 0.92, 1), 'auto')
+  }
+}
+
+async function renderBpmn() {
   if (isRendered.value) return
   isRendered.value = true
 
   const result = await withLoading(async () => {
-    await waitForContainer()
-
-    modeler = new BpmnModeler({
-      container: containerRef.value!,
-    })
-
-    if (props.bpmnFilePath) {
-      const bpmnXml = await fetchBpmnXml(props.bpmnFilePath)
-      await modeler.importXML(bpmnXml)
-    } else {
-      await modeler.createDiagram()
-    }
-
-    const canvas = modeler.get('canvas') as any
-    canvas.resized()
-    canvas.zoom('fit-viewport', 'auto')
+    await renderViewer()
   })
 
   if (result === undefined && error.value) {
@@ -93,24 +181,53 @@ async function renderBpmn() {
   }
 }
 
-/**
- * Render on the component mount for PDF export compatibility.
- * In headless export mode, onSlideEnter doesn't fire.
- */
+async function openFullscreen() {
+  isFullscreen.value = true
+  await nextTick()
+  await waitForContainer(modelerContainerRef)
+
+  hasModelerChanges = false
+  modeler = new BpmnModeler({ container: modelerContainerRef.value! })
+
+  await modeler.importXML(currentXml.value!)
+
+  const eventBus = modeler.get('eventBus') as any
+  eventBus.on('commandStack.changed', () => { hasModelerChanges = true })
+  const canvas = modeler.get('canvas') as any
+  canvas.resized()
+  canvas.zoom('fit-viewport', 'auto')
+}
+
+async function closeFullscreen() {
+  if (modeler) {
+    if (hasModelerChanges) {
+      const { xml } = await modeler.saveXML({ format: true })
+      if (xml) currentXml.value = xml
+    }
+    modeler.destroy()
+    modeler = null
+  }
+
+  isFullscreen.value = false
+
+  if (hasModelerChanges) {
+    await nextTick()
+    await renderViewer()
+  }
+}
+
 onMounted(async () => {
   await nextTick()
   await renderBpmn()
 })
 
-/**
- * Render when the slide becomes active in a live preview.
- * Container dimensions are only valid when the slide is visible.
- */
 onSlideEnter(async () => {
   await renderBpmn()
 })
 
 onUnmounted(() => {
+  viewer?.destroy()
+  viewer = null
   modeler?.destroy()
   modeler = null
 })

--- a/components/BpmnModeler.vue
+++ b/components/BpmnModeler.vue
@@ -182,6 +182,8 @@ async function renderBpmn() {
 }
 
 async function openFullscreen() {
+  if (!currentXml.value) return
+
   isFullscreen.value = true
   await nextTick()
   await waitForContainer(modelerContainerRef)
@@ -215,6 +217,8 @@ async function closeFullscreen() {
     await renderViewer()
   }
 }
+
+defineExpose({ openFullscreen, closeFullscreen })
 
 onMounted(async () => {
   await nextTick()

--- a/components/BpmnModeler.vue
+++ b/components/BpmnModeler.vue
@@ -1,0 +1,118 @@
+<template>
+  <div :style="{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: containerHeight }">
+    <p v-if="loading">Loading BPMN modeler...</p>
+    <p v-if="error" class="text-red-500">{{ error }}</p>
+    <div ref="containerRef" :style="{
+    width: `calc(${props.width} - ${margin * 2}px)`,
+    height: `calc(${containerHeight} - ${margin * 2}px)`,
+    margin: `${margin}px`,
+  }"
+    ></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+
+import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import BpmnModeler from 'bpmn-js/lib/Modeler'
+import 'bpmn-js/dist/assets/bpmn-js.css'
+import 'bpmn-js/dist/assets/diagram-js.css'
+import { onSlideEnter } from '@slidev/client'
+import { useBpmn } from '../composables/useBpmn'
+
+const margin = 5
+const containerWaitTimeout = 5000
+
+const { loading, error, fetchBpmnXml, withLoading } = useBpmn()
+const containerRef = ref<HTMLDivElement | null>(null)
+const isRendered = ref(false)
+let modeler: InstanceType<typeof BpmnModeler> | null = null
+
+const props = withDefaults(defineProps<{
+  bpmnFilePath?: string
+  width?: string
+  height?: string
+}>(), {
+  width: '100%',
+  height: '500px',
+})
+
+const containerHeight = props.height
+
+/**
+ * Polls for container dimensions to be ready before rendering.
+ * Prevents "non-finite" SVG matrix errors when canvas.zoom() is called.
+ */
+async function waitForContainer(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now()
+    const checkDimensions = () => {
+      if (containerRef.value && containerRef.value.clientWidth > 0 && containerRef.value.clientHeight > 0) {
+        resolve()
+      } else if (Date.now() - start > containerWaitTimeout) {
+        reject(new Error('Container dimensions not available within timeout'))
+      } else {
+        requestAnimationFrame(checkDimensions)
+      }
+    }
+    checkDimensions()
+  })
+}
+
+/**
+ * Renders the BPMN modeler.
+ * Includes duplicate prevention since Slidev calls both onMounted and onSlideEnter.
+ */
+async function renderBpmn() {
+
+  // Prevent duplicate rendering
+  if (isRendered.value) return
+  isRendered.value = true
+
+  const result = await withLoading(async () => {
+    await waitForContainer()
+
+    modeler = new BpmnModeler({
+      container: containerRef.value!,
+    })
+
+    if (props.bpmnFilePath) {
+      const bpmnXml = await fetchBpmnXml(props.bpmnFilePath)
+      await modeler.importXML(bpmnXml)
+    } else {
+      await modeler.createDiagram()
+    }
+
+    const canvas = modeler.get('canvas') as any
+    canvas.resized()
+    canvas.zoom('fit-viewport', 'auto')
+  })
+
+  if (result === undefined && error.value) {
+    isRendered.value = false
+  }
+}
+
+/**
+ * Render on the component mount for PDF export compatibility.
+ * In headless export mode, onSlideEnter doesn't fire.
+ */
+onMounted(async () => {
+  await nextTick()
+  await renderBpmn()
+})
+
+/**
+ * Render when the slide becomes active in a live preview.
+ * Container dimensions are only valid when the slide is visible.
+ */
+onSlideEnter(async () => {
+  await renderBpmn()
+})
+
+onUnmounted(() => {
+  modeler?.destroy()
+  modeler = null
+})
+
+</script>

--- a/example.md
+++ b/example.md
@@ -33,6 +33,7 @@ No manual export chaos, just saubere process diagrams!
 **Features:**
 - Static rendering for PDFs and presentations
 - Interactive token simulation for process demonstrations
+- Live BPMN modeling for workshops and trainings
 
 ---
 
@@ -49,3 +50,19 @@ The `Bpmn` component renders BPMN diagrams as static SVG images – koa screensh
 The `BpmnTokenSimulation` component adds animated token flow for process demonstrations – the tokens hupfan through your diagram like it's a Mordsgaudi! Your audience kapiert sofort how the workflow flows, koa langweiliges Gschwafel needed!
 
 <BpmnTokenSimulation bpmnFilePath="./newsletter.bpmn" height="350px"></BpmnTokenSimulation>
+
+---
+
+## Interactive BPMN Modeler
+
+The `BpmnModeler` component embeds a full BPMN editor – jetzt kannst du live in der Präsentation modellieren, so richtig gscheid! Perfect for workshops and trainings where you build diagrams step by step with your audience.
+
+<BpmnModeler bpmnFilePath="./newsletter.bpmn" height="400px"></BpmnModeler>
+
+---
+
+## Blank Canvas Modeler
+
+Start from scratch with a blank diagram – just a single start event to get you going. Ideal for live modeling sessions where you build a process together with your audience!
+
+<BpmnModeler height="400px"></BpmnModeler>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
       "devDependencies": {
         "@slidev/cli": "52.14.2",
         "@slidev/theme-default": "0.25.0",
-        "@vitejs/plugin-vue": "6.0.5",
+        "@vitejs/plugin-vue": "6.0.6",
         "@vue/test-utils": "2.4.6",
-        "jsdom": "26.1.0",
+        "jsdom": "29.0.2",
         "playwright-chromium": "1.59.1",
-        "vitest": "3.2.4"
+        "vitest": "4.1.4"
       },
       "engines": {
         "node": ">=20"
@@ -85,25 +85,43 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
       "dev": true,
-      "license": "ISC"
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -548,6 +566,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
@@ -608,9 +639,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
       "dev": true,
       "funding": [
         {
@@ -624,13 +655,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
       "dev": true,
       "funding": [
         {
@@ -644,17 +675,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
       "dev": true,
       "funding": [
         {
@@ -668,21 +699,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "dev": true,
       "funding": [
         {
@@ -696,16 +727,41 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
         {
@@ -719,7 +775,7 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@drauu/core": {
@@ -1209,6 +1265,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2011,9 +2085,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
-      "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3077,6 +3151,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3902,13 +3983,13 @@
       }
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.5.tgz",
-      "integrity": "sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
+      "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.2"
+        "@rolldown/pluginutils": "1.0.0-rc.13"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -3940,39 +4021,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -3994,42 +4076,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4037,28 +4119,25 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4477,16 +4556,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/alien-signals": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
@@ -4621,6 +4690,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -4853,18 +4932,11 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
@@ -4900,16 +4972,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chevrotain": {
@@ -5264,20 +5326,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/cssstyle": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^3.2.0",
-        "rrweb-cssom": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/csstype": {
@@ -5839,17 +5887,17 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/dayjs": {
@@ -5896,16 +5944,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/default-browser": {
@@ -6301,9 +6339,9 @@
       "optional": true
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6852,16 +6890,16 @@
       "license": "Apache-2.0"
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/html-void-elements": {
@@ -6895,40 +6933,12 @@
         "entities": "^7.0.1"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/https": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
       "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -7314,35 +7324,36 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -7351,6 +7362,16 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -7532,13 +7553,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -8691,13 +8705,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/nypm": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
@@ -8899,9 +8906,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8995,16 +9002,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/pdf-lib": {
       "version": "1.17.1",
@@ -9454,6 +9451,16 @@
         "regexp-tree": "bin/regexp-tree"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "dev": true,
@@ -9551,13 +9558,6 @@
         "points-on-curve": "^0.2.0",
         "points-on-path": "^0.2.1"
       }
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -9825,9 +9825,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -9919,26 +9919,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/style-value-types": {
       "version": "5.1.2",
@@ -10042,30 +10022,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10073,22 +10033,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.0.28"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10116,29 +10076,29 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^6.1.32"
+        "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -10331,6 +10291,16 @@
       "optional": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -10845,29 +10815,6 @@
         "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vite-plugin-inspect": {
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-11.3.3.tgz",
@@ -11069,65 +11016,79 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -11138,15 +11099,11 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
-    },
-    "node_modules/vitest/node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
@@ -11317,13 +11274,13 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/webpack-virtual-modules": {
@@ -11333,42 +11290,29 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -11509,28 +11453,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/wsl-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "slidev-addon-bpmn",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slidev-addon-bpmn",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "bpmn-js": "18.14.0",
         "bpmn-js-token-simulation": "0.39.3"
       },
       "devDependencies": {
-        "@slidev/cli": "52.14.1",
+        "@slidev/cli": "52.14.2",
         "@slidev/theme-default": "0.25.0",
         "@vitejs/plugin-vue": "6.0.6",
         "@vue/test-utils": "2.4.6",
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2734,9 +2734,9 @@
       "license": "MIT"
     },
     "node_modules/@slidev/cli": {
-      "version": "52.14.1",
-      "resolved": "https://registry.npmjs.org/@slidev/cli/-/cli-52.14.1.tgz",
-      "integrity": "sha512-+MGK+9556M+XRXZ7Ut8uU4AIlHU9k+GtQWGGmpmBY/SnWvW/sE5c5ZR9uJ1gmne6gZ3rh5GLm6KhnWPq9+OmTg==",
+      "version": "52.14.2",
+      "resolved": "https://registry.npmjs.org/@slidev/cli/-/cli-52.14.2.tgz",
+      "integrity": "sha512-D1juwO4kFFjArYCkRuN5FDdqcoFUG1ZGHVQTTaDZS5dz5rdQ9dPUnzmpMWr6QfFYGA+LXLfmqsR5Lrq/i4Ye9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2750,9 +2750,9 @@
         "@shikijs/markdown-it": "^4.0.1",
         "@shikijs/twoslash": "^4.0.1",
         "@shikijs/vitepress-twoslash": "^4.0.1",
-        "@slidev/client": "52.14.1",
-        "@slidev/parser": "52.14.1",
-        "@slidev/types": "52.14.1",
+        "@slidev/client": "52.14.2",
+        "@slidev/parser": "52.14.2",
+        "@slidev/types": "52.14.2",
         "@unocss/extractor-mdc": "^66.6.3",
         "@unocss/reset": "^66.6.3",
         "@vitejs/plugin-vue": "^6.0.4",
@@ -2815,7 +2815,7 @@
         "slidev": "bin/slidev.mjs"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2916,9 +2916,9 @@
       }
     },
     "node_modules/@slidev/client": {
-      "version": "52.14.1",
-      "resolved": "https://registry.npmjs.org/@slidev/client/-/client-52.14.1.tgz",
-      "integrity": "sha512-aljFqR3wNhaqcOxjm3jo0DyyTnD7H8BOTwnAFFIsb4j+p3ufMh/rx39GfQF2j+ABy4K3o+L/Ue+QsA2nLNmIHg==",
+      "version": "52.14.2",
+      "resolved": "https://registry.npmjs.org/@slidev/client/-/client-52.14.2.tgz",
+      "integrity": "sha512-fwBEbYkYFCwu1SWgknOYD5eD561rmCPxYteklhT0k+KnitLXMN5EpcM50TnoZ6IElfeMiwMv4Nq5f13L0OyCjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2929,9 +2929,9 @@
         "@shikijs/engine-javascript": "^4.0.1",
         "@shikijs/monaco": "^4.0.1",
         "@shikijs/vitepress-twoslash": "^4.0.1",
-        "@slidev/parser": "52.14.1",
+        "@slidev/parser": "52.14.2",
         "@slidev/rough-notation": "^0.1.0",
-        "@slidev/types": "52.14.1",
+        "@slidev/types": "52.14.2",
         "@typescript/ata": "^0.9.8",
         "@unhead/vue": "^2.1.10",
         "@unocss/extractor-mdc": "^66.6.3",
@@ -2961,7 +2961,7 @@
         "yaml": "^2.8.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3028,18 +3028,18 @@
       }
     },
     "node_modules/@slidev/parser": {
-      "version": "52.14.1",
-      "resolved": "https://registry.npmjs.org/@slidev/parser/-/parser-52.14.1.tgz",
-      "integrity": "sha512-Y/9aYcyzj5PGAflO0IPBwb3qs7OohfDc4kcHl149hGLceHo9jfZZh20V10NyK/R8IYTRJDgALbEHN/16jSRaqg==",
+      "version": "52.14.2",
+      "resolved": "https://registry.npmjs.org/@slidev/parser/-/parser-52.14.2.tgz",
+      "integrity": "sha512-HxKhO6ULub45A4nSkDIcnlfnNkARCJfmVKnpvoSn4R/QG9wRa29cGiOOR6PUT9atDZF+LEqisoUTLqiZp0NH0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@antfu/utils": "^9.3.0",
-        "@slidev/types": "52.14.1",
+        "@slidev/types": "52.14.2",
         "yaml": "^2.8.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3084,9 +3084,9 @@
       }
     },
     "node_modules/@slidev/types": {
-      "version": "52.14.1",
-      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-52.14.1.tgz",
-      "integrity": "sha512-48wp+YRCT8mckFAdu7hGX8DICRrqSpaDNOikQT087jvzCT/D7dr15wA+QTVRJiSLHr5yJVQAlX2lVD/Izhg0FQ==",
+      "version": "52.14.2",
+      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-52.14.2.tgz",
+      "integrity": "sha512-ucQbadhsg6IjidEmZevNGBxLlW6i2JS8YkIRwpFDKRMg7oJdi6mztp2Zq/Ca4hFdVr3iBo1Atny6ov0qUKE22A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3109,7 +3109,7 @@
         "vue-router": "^5.0.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -6312,9 +6312,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.336",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
-      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "version": "1.5.339",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
+      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "slidev-addon-bpmn",
-  "version": "1.3.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slidev-addon-bpmn",
-      "version": "1.3.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "bpmn-js": "18.14.0",
         "bpmn-js-token-simulation": "0.39.3"
       },
       "devDependencies": {
-        "@slidev/cli": "52.14.2",
+        "@slidev/cli": "52.14.1",
         "@slidev/theme-default": "0.25.0",
         "@vitejs/plugin-vue": "6.0.6",
         "@vue/test-utils": "2.4.6",
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1671,9 +1671,9 @@
       "license": "MIT"
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.115.0.tgz",
-      "integrity": "sha512-VoB2rhgoqgYf64d6Qs5emONQW8ASiTc0xp+aUE4JUhxjX+0pE3gblTYDO0upcN5vt9UlBNmUhAwfSifkfre7nw==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.124.0.tgz",
+      "integrity": "sha512-+R9zCafSL8ovjokdPtorUp3sXrh8zQ2AC2L0ivXNvlLR0WS+5WdPkNVrnENq5UvzagM4Xgl0NPsJKz3Hv9+y8g==",
       "cpu": [
         "arm"
       ],
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.115.0.tgz",
-      "integrity": "sha512-lWRX75u+gqfB4TF3pWCHuvhaeneAmRl2b2qNBcl4S6yJ0HtnT4VXOMEZrq747i4Zby1ZTxj6mtOe678Bg8gRLw==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.124.0.tgz",
+      "integrity": "sha512-ULHC/gVZ+nP4pd3kNNQTYaQ/e066BW/KuY5qUsvwkVWwOUQGDg+WpfyVOmQ4xfxoue6cMlkKkJ+ntdzfDXpNlg==",
       "cpu": [
         "arm64"
       ],
@@ -1705,9 +1705,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.115.0.tgz",
-      "integrity": "sha512-ii/oOZjfGY1aszXTy29Z5DRyCEnBOrAXDVCvfdfXFQsOZlbbOa7NMHD7D+06YFe5qdxfmbWAYv4yn6QJi/0d2g==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.124.0.tgz",
+      "integrity": "sha512-fGJ2hw7bnbUYn6UvTjp0m4WJ9zXz3cohgcwcgeo7gUZehpPNpvcVEVeIVHNmHnAuAw/ysf4YJR8DA1E+xCA4Lw==",
       "cpu": [
         "arm64"
       ],
@@ -1722,9 +1722,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.115.0.tgz",
-      "integrity": "sha512-R/sW/p8l77wglbjpMcF+h/3rWbp9zk1mRP3U14mxTYIC2k3m+aLBpXXgk2zksqf9qKk5mcc4GIYsuCn9l8TgDg==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.124.0.tgz",
+      "integrity": "sha512-j0+re9pgps5BH2Tk3fm59Hi3QuLP3C4KhqXi6A+wRHHHJWDFR8mc/KI9mBrfk2JRT+15doGo+zv1eN75/9DuOw==",
       "cpu": [
         "x64"
       ],
@@ -1739,9 +1739,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.115.0.tgz",
-      "integrity": "sha512-CSJ5ldNm9wIGGkhaIJeGmxRMZbgxThRN+X1ufYQQUNi5jZDV/U3C2QDMywpP93fczNBj961hXtcUPO/oVGq4Pw==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.124.0.tgz",
+      "integrity": "sha512-0k5mS0npnrhKy72UfF51lpOZ2ESoPWn6gdFw+RdeRWcokraDW1O2kSx3laQ+yk7cCEavQdJSpWCYS/GvBbUCXQ==",
       "cpu": [
         "x64"
       ],
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.115.0.tgz",
-      "integrity": "sha512-uWFwssE5dHfQ8lH+ktrsD9JA49+Qa0gtxZHUs62z1e91NgGz6O7jefHGI6aygNyKNS45pnnBSDSP/zV977MsOQ==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.124.0.tgz",
+      "integrity": "sha512-P/i4eguRWvAUfGdfhQYg1jpwYkyUV6D3gefIH7HhmRl1Ph6P4IqTIEVcyJr1i/3vr1V5OHU4wonH6/ue/Qzvrw==",
       "cpu": [
         "arm"
       ],
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.115.0.tgz",
-      "integrity": "sha512-fZbqt8y/sKQ+v6bBCuv/mYYFoC0+fZI3mGDDEemmDOhT78+aUs2+4ZMdbd2btlXmnLaScl37r8IRbhnok5Ka9w==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.124.0.tgz",
+      "integrity": "sha512-/ameqFQH5fFP+66Atr8Ynv/2rYe4utcU7L4MoWS5JtrFLVO78g4qDLavyIlJxa6caSwYOvG/eO3c/DXqY5/6Rw==",
       "cpu": [
         "arm"
       ],
@@ -1790,13 +1790,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.115.0.tgz",
-      "integrity": "sha512-1ej/MjuTY9tJEunU/hUPIFmgH5PqgMQoRjNOvOkibtJ3Zqlw/+Lc+HGHDNET8sjbgIkWzdhX+p4J96A5CPdbag==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.124.0.tgz",
+      "integrity": "sha512-gNeyEcXTtfrRCbj2EfxWU85Fs0wIX3p44Y3twnvuMfkWlLrb9M1Z25AYNSKjJM+fdAjeeQCjw0on47zFuBYwQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1807,13 +1810,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.115.0.tgz",
-      "integrity": "sha512-HjsZbJPH9mMd4swJRywVMsDZsJX0hyKb1iNHo5ijRl5yhtbO3lj7ImSrrL1oZ1VEg0te4iKmDGGz/6YPLd1G8w==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.124.0.tgz",
+      "integrity": "sha512-uvG7v4Tz9S8/PVqY0SP0DLHxo4hZGe+Pv2tGVnwcsjKCCUPjplbrFVvDzXq+kOaEoUkiCY0Kt1hlZ6FDJ1LKNQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1824,13 +1830,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.115.0.tgz",
-      "integrity": "sha512-zhhePoBrd7kQx3oClX/W6NldsuCbuMqaN9rRsY+6/WoorAb4j490PG/FjqgAXscWp2uSW2WV9L+ksn0wHrvsrg==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.124.0.tgz",
+      "integrity": "sha512-t7KZaaUhfp2au0MRpoENEFqwLKYDdptEry6V7pTAVdPEcFG4P6ii8yeGU9m6p5vb+b8WEKmdpGMNXBEYy7iJdw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1841,13 +1850,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.115.0.tgz",
-      "integrity": "sha512-t/IRojvUE9XrKu+/H1b8YINug+7Q6FLls5rsm2lxB5mnS8GN/eYAYrPgHkcg9/1SueRDSzGpDYu3lGWTObk1zw==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.124.0.tgz",
+      "integrity": "sha512-eurGGaxHZiIQ+fBSageS8TAkRqZgdOiBeqNrWAqAPup9hXBTmQ0WcBjwsLElf+3jvDL9NhnX0dOgOqPfsjSjdg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1858,13 +1870,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.115.0.tgz",
-      "integrity": "sha512-79jBHSSh/YpQRAmvYoaCfpyToRbJ/HBrdB7hxK2ku2JMehjopTVo+xMJss/RV7/ZYqeezgjvKDQzapJbgcjVZA==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.124.0.tgz",
+      "integrity": "sha512-d1V7/ll1i/LhqE/gZy6Wbz6evlk0egh2XKkwMI3epiojtbtUwQSLIER0Y3yDBBocPuWOjJdvmjtEmPTTLXje/w==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1875,13 +1890,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.115.0.tgz",
-      "integrity": "sha512-nA1TpxkhNTIOMMyiSSsa7XIVJVoOU/SsVrHIz3gHvWweB5PHCQfO7w+Lb2EP0lBWokv7HtA/KbF7aLDoXzmuMw==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.124.0.tgz",
+      "integrity": "sha512-w1+cBvriUteOpox6ATqCFVkpGL47PFdcfCPGmgUZbd78Fw44U0gQkc+kVGvAOTvGrptMYgwomD1c6OTVvkrpGg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1892,13 +1910,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.115.0.tgz",
-      "integrity": "sha512-9iVX789DoC3SaOOG+X6NcF/tVChgLp2vcHffzOC2/Z1JTPlz6bMG2ogvcW6/9s0BG2qvhNQImd+gbWYeQbOwVw==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.124.0.tgz",
+      "integrity": "sha512-RRB1evQiXRtMCsQQiAh9U0H3HzguLpE0ytfStuhRgmOj7tqUCOVxkHsvM9geZjAax6NqVRj7VXx32qjjkZPsBw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1909,13 +1930,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.115.0.tgz",
-      "integrity": "sha512-RmQmk+mjCB0nMNfEYhaCxwofLo1Z95ebHw1AGvRiWGCd4zhCNOyskgCbMogIcQzSB3SuEKWgkssyaiQYVAA4hQ==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.124.0.tgz",
+      "integrity": "sha512-asVYN0qmSHlCU8H9Q47SmeJ/Z5EG4IWCC+QGxkfFboI5qh15aLlJnHmnrV61MwQRPXGnVC/sC3qKhrUyqGxUqw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1926,9 +1950,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.115.0.tgz",
-      "integrity": "sha512-viigraWWQhhDvX5aGq+wrQq58k00Xq3MHz/0R4AFMxGlZ8ogNonpEfNc73Q5Ly87Z6sU9BvxEdG0dnYTfVnmew==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.124.0.tgz",
+      "integrity": "sha512-nhwuxm6B8pn9lzAzMUfa571L5hCXYwQo8C8cx5aGOuHWCzruR8gPJnRRXGBci+uGaIIQEZDyU/U6HDgrSp/JlQ==",
       "cpu": [
         "arm64"
       ],
@@ -1943,9 +1967,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.115.0.tgz",
-      "integrity": "sha512-IzGCrMwXhpb4kTXy/8lnqqqwjI7eOvy+r9AhVw+hsr8t1ecBBEHprcNy0aKatFHN6hsX7UMHHQmBAQjVvL/p1A==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.124.0.tgz",
+      "integrity": "sha512-LWuq4Dl9tff7n+HjJcqoBjDlVCtruc0shgtdtGM+rTUIE9aFxHA/P+wCYR+aWMjN8m9vNaRME/sKXErmhmeKrA==",
       "cpu": [
         "wasm32"
       ],
@@ -1953,16 +1977,16 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@napi-rs/wasm-runtime": "^1.1.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.115.0.tgz",
-      "integrity": "sha512-/ym+Absk/TLFvbhh3se9XYuI1D7BrUVHw4RaG/2dmWKgBenrZHaJsgnRb7NJtaOyjEOLIPtULx1wDdVL0SX2eg==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.124.0.tgz",
+      "integrity": "sha512-aOh3Lf3AeH0dgzT4yBXcArFZ8VhqNXwZ/xlN0GqBtgVaGoHOOqL2YHlcVIgT+ghsXPVR2PTtYgBiQ1CNK7jp5A==",
       "cpu": [
         "arm64"
       ],
@@ -1977,9 +2001,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.115.0.tgz",
-      "integrity": "sha512-AQSZjIR+b+Te7uaO/hGTMjT8/oxlYrvKrOTi4KTHF/O6osjHEatUQ3y6ZW2+8+lJxy20zIcGz6iQFmFq/qDKkg==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.124.0.tgz",
+      "integrity": "sha512-sib5xC0nz/+SCpaETBuHBz4SXS02KuG5HtyOcHsO/SK5ZvLRGhOZx0elDKawjb6adFkD7dQCqpXUS25wY6ELKQ==",
       "cpu": [
         "ia32"
       ],
@@ -1994,9 +2018,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.115.0.tgz",
-      "integrity": "sha512-oxUl82N+fIO9jIaXPph8SPPHQXrA08BHokBBJW8ct9F/x6o6bZE6eUAhUtWajbtvFhL8UYcCWRMba+kww6MBlA==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.124.0.tgz",
+      "integrity": "sha512-UgojtjGUgZgAZQYt7SC6VO65OVdxEkRe2q+2vbHJO//18qw3Hrk6UvHGQKldsQKgbVcIBT/YBrt85YberiYIPQ==",
       "cpu": [
         "x64"
       ],
@@ -2011,9 +2035,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
-      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2710,9 +2734,9 @@
       "license": "MIT"
     },
     "node_modules/@slidev/cli": {
-      "version": "52.14.2",
-      "resolved": "https://registry.npmjs.org/@slidev/cli/-/cli-52.14.2.tgz",
-      "integrity": "sha512-D1juwO4kFFjArYCkRuN5FDdqcoFUG1ZGHVQTTaDZS5dz5rdQ9dPUnzmpMWr6QfFYGA+LXLfmqsR5Lrq/i4Ye9Q==",
+      "version": "52.14.1",
+      "resolved": "https://registry.npmjs.org/@slidev/cli/-/cli-52.14.1.tgz",
+      "integrity": "sha512-+MGK+9556M+XRXZ7Ut8uU4AIlHU9k+GtQWGGmpmBY/SnWvW/sE5c5ZR9uJ1gmne6gZ3rh5GLm6KhnWPq9+OmTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2726,9 +2750,9 @@
         "@shikijs/markdown-it": "^4.0.1",
         "@shikijs/twoslash": "^4.0.1",
         "@shikijs/vitepress-twoslash": "^4.0.1",
-        "@slidev/client": "52.14.2",
-        "@slidev/parser": "52.14.2",
-        "@slidev/types": "52.14.2",
+        "@slidev/client": "52.14.1",
+        "@slidev/parser": "52.14.1",
+        "@slidev/types": "52.14.1",
         "@unocss/extractor-mdc": "^66.6.3",
         "@unocss/reset": "^66.6.3",
         "@vitejs/plugin-vue": "^6.0.4",
@@ -2791,7 +2815,7 @@
         "slidev": "bin/slidev.mjs"
       },
       "engines": {
-        "node": ">=20.12.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2892,9 +2916,9 @@
       }
     },
     "node_modules/@slidev/client": {
-      "version": "52.14.2",
-      "resolved": "https://registry.npmjs.org/@slidev/client/-/client-52.14.2.tgz",
-      "integrity": "sha512-fwBEbYkYFCwu1SWgknOYD5eD561rmCPxYteklhT0k+KnitLXMN5EpcM50TnoZ6IElfeMiwMv4Nq5f13L0OyCjw==",
+      "version": "52.14.1",
+      "resolved": "https://registry.npmjs.org/@slidev/client/-/client-52.14.1.tgz",
+      "integrity": "sha512-aljFqR3wNhaqcOxjm3jo0DyyTnD7H8BOTwnAFFIsb4j+p3ufMh/rx39GfQF2j+ABy4K3o+L/Ue+QsA2nLNmIHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2905,9 +2929,9 @@
         "@shikijs/engine-javascript": "^4.0.1",
         "@shikijs/monaco": "^4.0.1",
         "@shikijs/vitepress-twoslash": "^4.0.1",
-        "@slidev/parser": "52.14.2",
+        "@slidev/parser": "52.14.1",
         "@slidev/rough-notation": "^0.1.0",
-        "@slidev/types": "52.14.2",
+        "@slidev/types": "52.14.1",
         "@typescript/ata": "^0.9.8",
         "@unhead/vue": "^2.1.10",
         "@unocss/extractor-mdc": "^66.6.3",
@@ -2937,7 +2961,7 @@
         "yaml": "^2.8.2"
       },
       "engines": {
-        "node": ">=20.12.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3004,18 +3028,18 @@
       }
     },
     "node_modules/@slidev/parser": {
-      "version": "52.14.2",
-      "resolved": "https://registry.npmjs.org/@slidev/parser/-/parser-52.14.2.tgz",
-      "integrity": "sha512-HxKhO6ULub45A4nSkDIcnlfnNkARCJfmVKnpvoSn4R/QG9wRa29cGiOOR6PUT9atDZF+LEqisoUTLqiZp0NH0Q==",
+      "version": "52.14.1",
+      "resolved": "https://registry.npmjs.org/@slidev/parser/-/parser-52.14.1.tgz",
+      "integrity": "sha512-Y/9aYcyzj5PGAflO0IPBwb3qs7OohfDc4kcHl149hGLceHo9jfZZh20V10NyK/R8IYTRJDgALbEHN/16jSRaqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@antfu/utils": "^9.3.0",
-        "@slidev/types": "52.14.2",
+        "@slidev/types": "52.14.1",
         "yaml": "^2.8.2"
       },
       "engines": {
-        "node": ">=20.12.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3060,9 +3084,9 @@
       }
     },
     "node_modules/@slidev/types": {
-      "version": "52.14.2",
-      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-52.14.2.tgz",
-      "integrity": "sha512-ucQbadhsg6IjidEmZevNGBxLlW6i2JS8YkIRwpFDKRMg7oJdi6mztp2Zq/Ca4hFdVr3iBo1Atny6ov0qUKE22A==",
+      "version": "52.14.1",
+      "resolved": "https://registry.npmjs.org/@slidev/types/-/types-52.14.1.tgz",
+      "integrity": "sha512-48wp+YRCT8mckFAdu7hGX8DICRrqSpaDNOikQT087jvzCT/D7dr15wA+QTVRJiSLHr5yJVQAlX2lVD/Izhg0FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3085,7 +3109,7 @@
         "vue-router": "^5.0.3"
       },
       "engines": {
-        "node": ">=20.12.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3627,26 +3651,26 @@
       }
     },
     "node_modules/@unocss/cli": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/cli/-/cli-66.6.7.tgz",
-      "integrity": "sha512-m/yW5HMVyxfAOeyO4OyA4JB9dY+/gTsk25ucI8xVCFVDEENPEGr+vEqTDOA+vfe6pdURtyDYS7OrhikIRU1WNA==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/cli/-/cli-66.6.8.tgz",
+      "integrity": "sha512-dJ4AmrhCtQwEDJtpFG7AgJ4Qi4GWnNgWWlLWq4DhKBOCcvldr9k98mscdhs3MOwph25DIxU5MdLRAg/OS1JryQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "@unocss/config": "66.6.7",
-        "@unocss/core": "66.6.7",
-        "@unocss/preset-wind3": "66.6.7",
-        "@unocss/preset-wind4": "66.6.7",
-        "@unocss/transformer-directives": "66.6.7",
-        "cac": "^6.7.14",
+        "@unocss/config": "66.6.8",
+        "@unocss/core": "66.6.8",
+        "@unocss/preset-wind3": "66.6.8",
+        "@unocss/preset-wind4": "66.6.8",
+        "@unocss/transformer-directives": "66.6.8",
+        "cac": "^7.0.0",
         "chokidar": "^5.0.0",
         "colorette": "^2.0.20",
         "consola": "^3.4.2",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3",
         "perfect-debounce": "^2.1.0",
-        "tinyglobby": "^0.2.15",
+        "tinyglobby": "^0.2.16",
         "unplugin-utils": "^0.3.1"
       },
       "bin": {
@@ -3660,13 +3684,13 @@
       }
     },
     "node_modules/@unocss/config": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/config/-/config-66.6.7.tgz",
-      "integrity": "sha512-1uleyRLyJc6PNNc2L3hEaKL89zXwvQAtP36oFySgL47RAxZHPZ4vfqFpbwR0eEN4iSqTS24ZFr7CTRWCaEGjzQ==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/config/-/config-66.6.8.tgz",
+      "integrity": "sha512-f+a8OyhD7ZoK8Pa1b3Cbx1RQc3n5x+Qht/cHg3wh/g4DNQIjBI2EqwSLfBigWhdO96zIqFAdyTlO3onmrJwUOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
+        "@unocss/core": "66.6.8",
         "colorette": "^2.0.20",
         "consola": "^3.4.2",
         "unconfig": "^7.5.0"
@@ -3679,9 +3703,9 @@
       }
     },
     "node_modules/@unocss/core": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/core/-/core-66.6.7.tgz",
-      "integrity": "sha512-Q8456iWFtdwrUNYKVOQY8ygRggjZOVtLc6Jc8KIkxig7OiNlUWOgXJTfCh4I8g6jBYzC5eHaHFDLgJOmOrxBsg==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/core/-/core-66.6.8.tgz",
+      "integrity": "sha512-P9IlQfgms+8/nka7fBhiiWU4SPwrTNKbTdK0z1SLnttXMHHjsB2zpG+Vi1JQDpICfY9Y1/2pWtguPE+zeOVu9Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3689,22 +3713,22 @@
       }
     },
     "node_modules/@unocss/extractor-arbitrary-variants": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/extractor-arbitrary-variants/-/extractor-arbitrary-variants-66.6.7.tgz",
-      "integrity": "sha512-PQiBHK0yUJ0BR+3GYnTPU6va6HVSRPV+O+s1zZmt23TWbyIeucoKCNR47TDtv+Z1xuksY8krIjtDYtufdrVWKw==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/extractor-arbitrary-variants/-/extractor-arbitrary-variants-66.6.8.tgz",
+      "integrity": "sha512-cOXstpPTOLt/HYcL0OsqFkNau0e8ktZ5Q8fgnXBZjmLGmi+VzdESNlwxZyCXLuamZGnbrZ8lDsKdsGG7P1pMKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7"
+        "@unocss/core": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/extractor-mdc": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/extractor-mdc/-/extractor-mdc-66.6.7.tgz",
-      "integrity": "sha512-evWRx++2eY9drt1WP0xYsx3eOvc5/YP2P2FAwtJVM/0F00IAhfXg6mqKjnrz+GXXXEKDNtzr2qsf8G2Z7wtuJA==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/extractor-mdc/-/extractor-mdc-66.6.8.tgz",
+      "integrity": "sha512-l4TZ/5PRRqYup3GB0CwcUGG7CRt4+d1FLqNppjRn3mGR8ILtqZSmZvX1mU7Y90rGjORfE3bLJ0XA0JS2w7Gm5g==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3712,14 +3736,14 @@
       }
     },
     "node_modules/@unocss/inspector": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/inspector/-/inspector-66.6.7.tgz",
-      "integrity": "sha512-4lA70A/wy9dfSDm7rJ5Uq5fKz+/Szm2rUcHjdbLCVNEc6vv2YXeI7aFvP5qDjTp4ClBSF2AMPnF1mtoMQOfDvA==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/inspector/-/inspector-66.6.8.tgz",
+      "integrity": "sha512-g8uRzXDdmoNRjXX/mZP7m0rWXLtOimyOW7+VFK6FNxRWBmvIGYgTLHkutF6Wyh9lLPDYx3pkkEmfgL35BDT3Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
-        "@unocss/rule-utils": "66.6.7",
+        "@unocss/core": "66.6.8",
+        "@unocss/rule-utils": "66.6.8",
         "colorette": "^2.0.20",
         "gzip-size": "^6.0.0",
         "sirv": "^3.0.2"
@@ -3729,27 +3753,27 @@
       }
     },
     "node_modules/@unocss/preset-attributify": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-attributify/-/preset-attributify-66.6.7.tgz",
-      "integrity": "sha512-thtoLQb53+Acy2QJYT6n+YhgNJ5ilhS8k9bqi+UzflbsuK4TJqOuQQjC9fRkULP5QjtNxgqN3d5Up7ms8tBPDA==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-attributify/-/preset-attributify-66.6.8.tgz",
+      "integrity": "sha512-YxyRSF5rq0WbY8kCG0gpj3DSXPL89QGxZeqABmceCzPJbXJBBHEJz/pgBPmzSa2Ziulgs0AEkHzWFPfpb2uGTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7"
+        "@unocss/core": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-icons": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-icons/-/preset-icons-66.6.7.tgz",
-      "integrity": "sha512-mGAOyI/qz1pZUV1BcOtWAMm5czdFCjhFCYcDk0KY+Jw37pKRVSQRFeh4gpHuYKmehGv36caLyVrWXpTAwRBdFQ==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-icons/-/preset-icons-66.6.8.tgz",
+      "integrity": "sha512-+zD5TNGZIXvVOMcvDIYaTXinffpDMERGj6Ch8WTtJluA6qHHBvRuFexoU2bY8nF1r0HZkYzNT9C+RujFSP+6TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@iconify/utils": "^3.1.0",
-        "@unocss/core": "66.6.7",
+        "@unocss/core": "66.6.8",
         "ofetch": "^1.5.1"
       },
       "funding": {
@@ -3757,66 +3781,66 @@
       }
     },
     "node_modules/@unocss/preset-mini": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-mini/-/preset-mini-66.6.7.tgz",
-      "integrity": "sha512-tf0mqiSEhPQ49WZOqjNhxlbZbNakiBLzCoxfLSzqfIGglOPYShP8mxsdp9Jv0n+Ntn0rHcBiX5KTLfax1/Bd9g==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-mini/-/preset-mini-66.6.8.tgz",
+      "integrity": "sha512-vAechrReO7LtWzFAeF54P7CintG2m65SlVlBsi1x2Ru7IdgUNJEHII0MfXUvf9r1x8vsIlhATyaqqtBVT6ps/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
-        "@unocss/extractor-arbitrary-variants": "66.6.7",
-        "@unocss/rule-utils": "66.6.7"
+        "@unocss/core": "66.6.8",
+        "@unocss/extractor-arbitrary-variants": "66.6.8",
+        "@unocss/rule-utils": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-tagify": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-tagify/-/preset-tagify-66.6.7.tgz",
-      "integrity": "sha512-0WeQf+Dx9Ztv3aewkBKEnAfOauSjvWBlfkpsgLpXcCkyGMnCqq87UrAq3+b76TDJvQc8i2ADlvVGK7V1z0JZQg==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-tagify/-/preset-tagify-66.6.8.tgz",
+      "integrity": "sha512-cG6zBYswtWTpeQe/Lb1Bh+IzU4Ck+VI8rpYvrnvSGl22rJjAsXd+buB1P0PjyDpoe924rq0bLTayZ8r6Ayyyvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7"
+        "@unocss/core": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-typography": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-typography/-/preset-typography-66.6.7.tgz",
-      "integrity": "sha512-RA7MwPDD5N9xGrbWnguVm5tP+F4/n/9X1rJsq2nBjvvK2dbtIRJZjRFM1vBDsR0GIhtvbHMoTchZaSZed5I+Hw==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-typography/-/preset-typography-66.6.8.tgz",
+      "integrity": "sha512-wOApJpE0QfeOTWN5RuQts8zS6PXhTZIfjpt6cBj8dmv7+GlIQlwopxL7wcDb2wVwdCByuMvUbWl7nC3kz/iFTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
-        "@unocss/rule-utils": "66.6.7"
+        "@unocss/core": "66.6.8",
+        "@unocss/rule-utils": "66.6.8"
       }
     },
     "node_modules/@unocss/preset-uno": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-uno/-/preset-uno-66.6.7.tgz",
-      "integrity": "sha512-imGCe6Yv2XgrJxP77gV8WZCz0xL99MsGov5rYn64lh2/tcsHF2rUIhTj/Urgxt0kwk8rLFtGbR1JuwPMNL5EDw==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-uno/-/preset-uno-66.6.8.tgz",
+      "integrity": "sha512-z01Rw/rBuahRulwQRnobUFnGqyU+UenOLz72KGn4p0Yh8gBC44fPlNHsOWA0TNediHRJg33HptX4kx16HCVWDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
-        "@unocss/preset-wind3": "66.6.7"
+        "@unocss/core": "66.6.8",
+        "@unocss/preset-wind3": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-web-fonts": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-web-fonts/-/preset-web-fonts-66.6.7.tgz",
-      "integrity": "sha512-GLjUoSL/kYt1Yw2zpzixKnxvpHgLHAg0JXiPglct4PZ9YmUzCPbvJ/vVn+0AnB8Fxr29Z8NAFSNoX625ZaRonQ==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-web-fonts/-/preset-web-fonts-66.6.8.tgz",
+      "integrity": "sha512-AgEHO8h0AkeOT57AOE9PS7dJOa5Rfr0gIyz/FxA7vJ/FwgQL70uX+bRW8kmoH81zcjo5xBP2IX3Z6A8VAOo3Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
+        "@unocss/core": "66.6.8",
         "ofetch": "^1.5.1"
       },
       "funding": {
@@ -3824,53 +3848,53 @@
       }
     },
     "node_modules/@unocss/preset-wind": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-wind/-/preset-wind-66.6.7.tgz",
-      "integrity": "sha512-jxtAN96jljd+KglbhPv6Y/ujceI5rVdrLQimj4KUTPoYBPEiWadzsGKN3o8Q07hlPRg+hBlO0r4tGSUWl+/EZQ==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-wind/-/preset-wind-66.6.8.tgz",
+      "integrity": "sha512-F0mdmwK/HelYOgBRMHl+Yx/VyARCQJtPlcgPBejI3E9ZWOZlKS7hvPqPrgvS63WTGMHgM3/22cGuYYFjpi/ugA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
-        "@unocss/preset-wind3": "66.6.7"
+        "@unocss/core": "66.6.8",
+        "@unocss/preset-wind3": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-wind3": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-wind3/-/preset-wind3-66.6.7.tgz",
-      "integrity": "sha512-PKyqeRzlIMd3Irdt6fCKMm73zgwweiXESk5edUK8dVWndvPIcZCOqrEq7yg6Pr/Q8tHdq26viYSkVY3a3t8RSg==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-wind3/-/preset-wind3-66.6.8.tgz",
+      "integrity": "sha512-WNTeDAYCatmEFjBJ4itUmz0TElBvNFqjh5i2/ianDJO/vkd+IYUb03jEPLUppVlvMhy8bN8AunP0AtW3Xf2psA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
-        "@unocss/preset-mini": "66.6.7",
-        "@unocss/rule-utils": "66.6.7"
+        "@unocss/core": "66.6.8",
+        "@unocss/preset-mini": "66.6.8",
+        "@unocss/rule-utils": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/preset-wind4": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/preset-wind4/-/preset-wind4-66.6.7.tgz",
-      "integrity": "sha512-9grhWeBsFzpv8iER9AFATRaxLyXMCwGQ5HzeI4XZh2ZZ9O6vC7nYfGhns4/I+F/RpFglzU1bjqMWRS/DS8OpGQ==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/preset-wind4/-/preset-wind4-66.6.8.tgz",
+      "integrity": "sha512-CheOm7KXOsTI5t4RXgeYz95CO5p589F6jsyYp+inOCk4N0/d+DWiDHrQ+V0x0HWs3JXWlD+/Va/yXjlc3o2sIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
-        "@unocss/extractor-arbitrary-variants": "66.6.7",
-        "@unocss/rule-utils": "66.6.7"
+        "@unocss/core": "66.6.8",
+        "@unocss/extractor-arbitrary-variants": "66.6.8",
+        "@unocss/rule-utils": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/reset": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/reset/-/reset-66.6.7.tgz",
-      "integrity": "sha512-+OjpLDEaPmhTQ3Gj7EaKApNM92TM9f9gLgHNa79+66wIll9IfhKfEmJXnF9y1SE725n4PmPIQgC9k313HztMLA==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/reset/-/reset-66.6.8.tgz",
+      "integrity": "sha512-H+YP3ltizUiPO9FzFgFhv8WGsefO7fTgT1If1/9ritPDqZlvzTqMmjelhcq8D8MGoQ1RQBUvtkZ5HJoKVY0Tgw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3878,13 +3902,13 @@
       }
     },
     "node_modules/@unocss/rule-utils": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/rule-utils/-/rule-utils-66.6.7.tgz",
-      "integrity": "sha512-4PT/s8yKIShSqP9XPSw4EjbZopcu3wlIB9i3kbGbzQwF91H+0Yy10guK3kHDGtkmWVN6Np6VvaGIj2UcbmaivA==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/rule-utils/-/rule-utils-66.6.8.tgz",
+      "integrity": "sha512-WR35L07mLP6PElD4hlUHo5KbQ48uz2HT/XCuJyAsHP+15Gv6539hPWA5SresPuva9r8rl+PeGIgMSIKf4A5Ihw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "^66.6.7",
+        "@unocss/core": "^66.6.8",
         "magic-string": "^0.30.21"
       },
       "engines": {
@@ -3895,14 +3919,14 @@
       }
     },
     "node_modules/@unocss/transformer-attributify-jsx": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/transformer-attributify-jsx/-/transformer-attributify-jsx-66.6.7.tgz",
-      "integrity": "sha512-r5bsnaPVe4iySLK5G5rA/QPSKmpPjYT9lixEv+KElvZcqZ+cPpkGoo+E+rnTcapu9KDMOVJItH/4Zy9m4AQ1ZQ==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/transformer-attributify-jsx/-/transformer-attributify-jsx-66.6.8.tgz",
+      "integrity": "sha512-g+7lvm+8V1MnJ21ialTxFBonCTtenn/KcZQbm0JfvQjgG+KuuSnt3BGEcXAHQZu3eBDGuJuasTHiXWwzCYIRBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
-        "oxc-parser": "^0.115.0",
+        "@unocss/core": "66.6.8",
+        "oxc-parser": "^0.124.0",
         "oxc-walker": "^0.7.0"
       },
       "funding": {
@@ -3910,58 +3934,58 @@
       }
     },
     "node_modules/@unocss/transformer-compile-class": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/transformer-compile-class/-/transformer-compile-class-66.6.7.tgz",
-      "integrity": "sha512-4uz4jCyq8VUaSPveXhelUWUNaTnetPFvEmXzmbYJ5BygAlUlipNynffUlUusDQmBBRrfZhJNB5J1Zif2Q6oUiA==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/transformer-compile-class/-/transformer-compile-class-66.6.8.tgz",
+      "integrity": "sha512-37dFuzgYo8ki033KmuvyZXugQRVH1c3+/z5kcWLPhcMR8UJscAtjgRx80S1UvWup2q6TPxPpmy/rMbqWvs3jfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7"
+        "@unocss/core": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/transformer-directives": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/transformer-directives/-/transformer-directives-66.6.7.tgz",
-      "integrity": "sha512-z3gi8/cD2P0I+c6jOPZUtsPXknHwVNlMIitSh7LhyM6W3EqbqvDcYH2gFeGhdhoYcN2r5OpTBujq34iz4IdUxA==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/transformer-directives/-/transformer-directives-66.6.8.tgz",
+      "integrity": "sha512-9hC3mQ8eycliW/igI9le0LovTIMBKoL6crucTkr4MmWuNqICMvNxTmGj5Xh64olBPnascevFwam6xsy+J1lX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7",
-        "@unocss/rule-utils": "66.6.7",
-        "css-tree": "^3.1.0"
+        "@unocss/core": "66.6.8",
+        "@unocss/rule-utils": "66.6.8",
+        "css-tree": "^3.2.1"
       }
     },
     "node_modules/@unocss/transformer-variant-group": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/transformer-variant-group/-/transformer-variant-group-66.6.7.tgz",
-      "integrity": "sha512-XouJuQCjYJpvR3sY4QDXnGXxtyJ4qgWFG+S9bAB01TTslhQLvNPE9o2+4gZlltnJLqxiPQWuLeJA1KdPD6ciww==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/transformer-variant-group/-/transformer-variant-group-66.6.8.tgz",
+      "integrity": "sha512-+t7gJDW3W3z3/f8zBf0DfV2UZyGyFOwG5CIsIj5ofu3VJ91mKD/5ZAH8fD3cryXCBSqslj4yv+8R+BLV07T5AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/core": "66.6.7"
+        "@unocss/core": "66.6.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@unocss/vite": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/@unocss/vite/-/vite-66.6.7.tgz",
-      "integrity": "sha512-8AHrVzAecnQaPLJv3/mpyFt5j2iL3gEwkZcZ8HzjH5ttK2XON1YE9vgujN5NS/yvZwlJxCMNPxn0S410/Ek61A==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/@unocss/vite/-/vite-66.6.8.tgz",
+      "integrity": "sha512-bXfEnEHdW7zTGLIYU16MsfKSFy3Q47Pevhrt5f9fOGzC4UI1JGkkoQSfoFpXZGliDrhoSFK4Msz9Jt43Ta4j+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "@unocss/config": "66.6.7",
-        "@unocss/core": "66.6.7",
-        "@unocss/inspector": "66.6.7",
+        "@unocss/config": "66.6.8",
+        "@unocss/core": "66.6.8",
+        "@unocss/inspector": "66.6.8",
         "chokidar": "^5.0.0",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3",
-        "tinyglobby": "^0.2.15",
+        "tinyglobby": "^0.2.16",
         "unplugin-utils": "^0.3.1"
       },
       "funding": {
@@ -4680,9 +4704,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
-      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4890,19 +4914,19 @@
       }
     },
     "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -6188,9 +6212,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -6288,9 +6312,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.332",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.332.tgz",
-      "integrity": "sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==",
+      "version": "1.5.336",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -6877,9 +6901,9 @@
       "license": "MIT"
     },
     "node_modules/hookable": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.0.tgz",
-      "integrity": "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8823,13 +8847,13 @@
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.115.0.tgz",
-      "integrity": "sha512-2w7Xn3CbS/zwzSY82S5WLemrRu3CT57uF7Lx8llrE/2bul6iMTcJE4Rbls7GDNbLn3ttATI68PfOz2Pt3KZ2cQ==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.124.0.tgz",
+      "integrity": "sha512-h07SFj/tp2U3cf3+LFX6MmOguQiM9ahwpGs0ZK5CGhgL8p4kk24etrJKsEzhXAvo7mfvoKTZooZ5MLKAPRmJ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.115.0"
+        "@oxc-project/types": "^0.124.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -8838,26 +8862,26 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.115.0",
-        "@oxc-parser/binding-android-arm64": "0.115.0",
-        "@oxc-parser/binding-darwin-arm64": "0.115.0",
-        "@oxc-parser/binding-darwin-x64": "0.115.0",
-        "@oxc-parser/binding-freebsd-x64": "0.115.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.115.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.115.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.115.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.115.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.115.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.115.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.115.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.115.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.115.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.115.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.115.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.115.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.115.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.115.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.115.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.124.0",
+        "@oxc-parser/binding-android-arm64": "0.124.0",
+        "@oxc-parser/binding-darwin-arm64": "0.124.0",
+        "@oxc-parser/binding-darwin-x64": "0.124.0",
+        "@oxc-parser/binding-freebsd-x64": "0.124.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.124.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.124.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.124.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.124.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.124.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.124.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.124.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.124.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.124.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.124.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.124.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.124.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.124.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.124.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.124.0"
       }
     },
     "node_modules/oxc-walker": {
@@ -9034,9 +9058,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10006,14 +10030,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -10130,42 +10154,42 @@
       "license": "0BSD"
     },
     "node_modules/twoslash": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/twoslash/-/twoslash-0.3.6.tgz",
-      "integrity": "sha512-VuI5OKl+MaUO9UIW3rXKoPgHI3X40ZgB/j12VY6h98Ae1mCBihjPvhOPeJWlxCYcmSbmeZt5ZKkK0dsVtp+6pA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/twoslash/-/twoslash-0.3.7.tgz",
+      "integrity": "sha512-f7YgM+6G5e3wRGwMiOV8Z0wfusR4zCcdDPSqgGjpLSiW0ymT9r/dM6g++IvOMtSO0KnP/yGTUFhH04y6uqpL6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript/vfs": "^1.6.2",
-        "twoslash-protocol": "0.3.6"
+        "@typescript/vfs": "^1.6.4",
+        "twoslash-protocol": "0.3.7"
       },
       "peerDependencies": {
-        "typescript": "^5.5.0"
+        "typescript": "^5.5.0 || ^6.0.0"
       }
     },
     "node_modules/twoslash-protocol": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/twoslash-protocol/-/twoslash-protocol-0.3.6.tgz",
-      "integrity": "sha512-FHGsJ9Q+EsNr5bEbgG3hnbkvEBdW5STgPU824AHUjB4kw0Dn4p8tABT7Ncg1Ie6V0+mDg3Qpy41VafZXcQhWMA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/twoslash-protocol/-/twoslash-protocol-0.3.7.tgz",
+      "integrity": "sha512-mwDFdclG7DbFW3aZA/CGATzV2efV2uPai90mmRSblqPbrc1Z1cu+DpI5oKMNciGY4rw8EOXc7QGY8O0iw1hnzg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/twoslash-vue": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/twoslash-vue/-/twoslash-vue-0.3.6.tgz",
-      "integrity": "sha512-HXYxU+Y7jZiMXJN4980fQNMYflLD8uqKey1qVW5ri8bqYTm2t5ILmOoCOli7esdCHlMq4/No3iQUWBWDhZNs9w==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/twoslash-vue/-/twoslash-vue-0.3.7.tgz",
+      "integrity": "sha512-ReBiEd4xXIICSZDU06shPr+JNf5iFOfQjpjn2q/4vz7y6pEU4vNxEjjHL5hI+nbSASAO43CDOLbY9vXBH9yXUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/language-core": "^3.2.0",
-        "twoslash": "0.3.6",
-        "twoslash-protocol": "0.3.6"
+        "@vue/language-core": "^3.2.6",
+        "twoslash": "0.3.7",
+        "twoslash-protocol": "0.3.7"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
-        "typescript": "^5.5.0"
+        "typescript": "^5.5.0 || ^6.0.0"
       }
     },
     "node_modules/type-level-regexp": {
@@ -10397,29 +10421,29 @@
       }
     },
     "node_modules/unocss": {
-      "version": "66.6.7",
-      "resolved": "https://registry.npmjs.org/unocss/-/unocss-66.6.7.tgz",
-      "integrity": "sha512-TdZ/JnKhrqkknrMvLl0KOwrGzFThEspFIyYiylFYJki2JkMN/5EJIr+vIZEGRX69hFTjTLi6utIpbipueqzNbw==",
+      "version": "66.6.8",
+      "resolved": "https://registry.npmjs.org/unocss/-/unocss-66.6.8.tgz",
+      "integrity": "sha512-stq9FbxedTDkoWrxnNQNnPQXOaM6L2Lobq8HzjXdR2tMc55gtfqDArqL7TESfnN7qeZsIocNYCHLNA4DXq50YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@unocss/cli": "66.6.7",
-        "@unocss/core": "66.6.7",
-        "@unocss/preset-attributify": "66.6.7",
-        "@unocss/preset-icons": "66.6.7",
-        "@unocss/preset-mini": "66.6.7",
-        "@unocss/preset-tagify": "66.6.7",
-        "@unocss/preset-typography": "66.6.7",
-        "@unocss/preset-uno": "66.6.7",
-        "@unocss/preset-web-fonts": "66.6.7",
-        "@unocss/preset-wind": "66.6.7",
-        "@unocss/preset-wind3": "66.6.7",
-        "@unocss/preset-wind4": "66.6.7",
-        "@unocss/transformer-attributify-jsx": "66.6.7",
-        "@unocss/transformer-compile-class": "66.6.7",
-        "@unocss/transformer-directives": "66.6.7",
-        "@unocss/transformer-variant-group": "66.6.7",
-        "@unocss/vite": "66.6.7"
+        "@unocss/cli": "66.6.8",
+        "@unocss/core": "66.6.8",
+        "@unocss/preset-attributify": "66.6.8",
+        "@unocss/preset-icons": "66.6.8",
+        "@unocss/preset-mini": "66.6.8",
+        "@unocss/preset-tagify": "66.6.8",
+        "@unocss/preset-typography": "66.6.8",
+        "@unocss/preset-uno": "66.6.8",
+        "@unocss/preset-web-fonts": "66.6.8",
+        "@unocss/preset-wind": "66.6.8",
+        "@unocss/preset-wind3": "66.6.8",
+        "@unocss/preset-wind4": "66.6.8",
+        "@unocss/transformer-attributify-jsx": "66.6.8",
+        "@unocss/transformer-compile-class": "66.6.8",
+        "@unocss/transformer-directives": "66.6.8",
+        "@unocss/transformer-variant-group": "66.6.8",
+        "@unocss/vite": "66.6.8"
       },
       "engines": {
         "node": ">=14"
@@ -10428,9 +10452,9 @@
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
-        "@unocss/astro": "66.6.7",
-        "@unocss/postcss": "66.6.7",
-        "@unocss/webpack": "66.6.7"
+        "@unocss/astro": "66.6.8",
+        "@unocss/postcss": "66.6.8",
+        "@unocss/webpack": "66.6.8"
       },
       "peerDependenciesMeta": {
         "@unocss/astro": {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   "devDependencies": {
     "@slidev/cli": "52.14.2",
     "@slidev/theme-default": "0.25.0",
-    "@vitejs/plugin-vue": "6.0.5",
+    "@vitejs/plugin-vue": "6.0.6",
     "@vue/test-utils": "2.4.6",
-    "jsdom": "26.1.0",
+    "jsdom": "29.0.2",
     "playwright-chromium": "1.59.1",
-    "vitest": "3.2.4"
+    "vitest": "4.1.4"
   },
   "keywords": [
     "slidev",

--- a/tests/components/Bpmn.test.ts
+++ b/tests/components/Bpmn.test.ts
@@ -39,11 +39,13 @@ describe('Bpmn.vue', () => {
 
     mockImportXML.mockResolvedValue(undefined)
     mockSaveSVG.mockResolvedValue({ svg: SAMPLE_SVG })
-    MockBpmnViewer.mockImplementation(() => ({
-      importXML: mockImportXML,
-      saveSVG: mockSaveSVG,
-      destroy: mockDestroy,
-    }))
+    MockBpmnViewer.mockImplementation(function () {
+      return {
+        importXML: mockImportXML,
+        saveSVG: mockSaveSVG,
+        destroy: mockDestroy,
+      }
+    })
 
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })

--- a/tests/components/BpmnModeler.test.ts
+++ b/tests/components/BpmnModeler.test.ts
@@ -1,14 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 
-const { mockDestroy, mockImportXML, mockCreateDiagram, mockResized, mockZoom, mockGet, MockBpmnModeler } = vi.hoisted(() => ({
-  mockDestroy: vi.fn(),
+const { mockViewerDestroy, mockImportXML, mockResized, mockZoom, mockGet, MockBpmnViewer } = vi.hoisted(() => ({
+  mockViewerDestroy: vi.fn(),
   mockImportXML: vi.fn(),
-  mockCreateDiagram: vi.fn(),
   mockResized: vi.fn(),
   mockZoom: vi.fn(),
   mockGet: vi.fn(),
+  MockBpmnViewer: vi.fn(),
+}))
+
+const { mockModelerDestroy, mockCreateDiagram, mockSaveXML, MockBpmnModeler } = vi.hoisted(() => ({
+  mockModelerDestroy: vi.fn(),
+  mockCreateDiagram: vi.fn(),
+  mockSaveXML: vi.fn(),
   MockBpmnModeler: vi.fn(),
+}))
+
+vi.mock('bpmn-js/lib/Viewer', () => ({
+  default: MockBpmnViewer,
 }))
 
 vi.mock('bpmn-js/lib/Modeler', () => ({
@@ -17,6 +27,7 @@ vi.mock('bpmn-js/lib/Modeler', () => ({
 
 vi.mock('bpmn-js/dist/assets/bpmn-js.css', () => ({}))
 vi.mock('bpmn-js/dist/assets/diagram-js.css', () => ({}))
+vi.mock('bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css', () => ({}))
 
 const { slideEnterCallbacks } = vi.hoisted(() => ({
   slideEnterCallbacks: [] as Array<() => void>,
@@ -28,7 +39,7 @@ vi.mock('@slidev/client', () => ({
   }),
 }))
 
-import BpmnModeler from '../../components/BpmnModeler.vue'
+import BpmnModelerComponent from '../../components/BpmnModeler.vue'
 
 function mockFetchSuccess(xml = '<definitions></definitions>') {
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -55,22 +66,34 @@ function giveContainerDimensions(wrapper: ReturnType<typeof mount>) {
 describe('BpmnModeler.vue', () => {
   beforeEach(() => {
     slideEnterCallbacks.length = 0
-    mockDestroy.mockClear()
+    mockViewerDestroy.mockClear()
     mockImportXML.mockClear()
-    mockCreateDiagram.mockClear()
     mockResized.mockClear()
     mockZoom.mockClear()
     mockGet.mockClear()
+    MockBpmnViewer.mockClear()
+    mockModelerDestroy.mockClear()
+    mockCreateDiagram.mockClear()
+    mockSaveXML.mockClear()
     MockBpmnModeler.mockClear()
 
     mockImportXML.mockResolvedValue(undefined)
     mockCreateDiagram.mockResolvedValue(undefined)
-    mockGet.mockReturnValue({ resized: mockResized, zoom: mockZoom })
+    mockSaveXML.mockResolvedValue({ xml: '<definitions></definitions>' })
+    mockGet.mockReturnValue({ resized: mockResized, zoom: mockZoom, on: vi.fn() })
+    MockBpmnViewer.mockImplementation(function () {
+      return {
+        importXML: mockImportXML,
+        destroy: mockViewerDestroy,
+        get: mockGet,
+      }
+    })
     MockBpmnModeler.mockImplementation(function () {
       return {
         importXML: mockImportXML,
         createDiagram: mockCreateDiagram,
-        destroy: mockDestroy,
+        saveXML: mockSaveXML,
+        destroy: mockModelerDestroy,
         get: mockGet,
       }
     })
@@ -85,57 +108,89 @@ describe('BpmnModeler.vue', () => {
 
   it('shows loading state initially', () => {
     mockFetchSuccess()
-    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
-    expect(wrapper.text()).toContain('Loading BPMN modeler...')
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
+    expect(wrapper.text()).toContain('Loading BPMN diagram...')
   })
 
   it('defaults containerHeight to 500px', () => {
     mockFetchSuccess()
-    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
     const outerDiv = wrapper.find('div').element as HTMLDivElement
     expect(outerDiv.style.height).toBe('500px')
   })
 
   it('uses provided height for containerHeight', () => {
     mockFetchSuccess()
-    const wrapper = mount(BpmnModeler, {
+    const wrapper = mount(BpmnModelerComponent, {
       props: { bpmnFilePath: 'test.bpmn', height: '700px' },
     })
     const outerDiv = wrapper.find('div').element as HTMLDivElement
     expect(outerDiv.style.height).toBe('700px')
   })
 
-  it('renders with a file path when container has dimensions', async () => {
+  it('renders viewer with file path when container has dimensions', async () => {
     mockFetchSuccess()
-    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
     giveContainerDimensions(wrapper)
 
     await new Promise(resolve => setTimeout(resolve, 50))
     await flushPromises()
 
+    expect(MockBpmnViewer).toHaveBeenCalled()
     expect(mockImportXML).toHaveBeenCalled()
-    expect(mockCreateDiagram).not.toHaveBeenCalled()
     expect(mockResized).toHaveBeenCalled()
     expect(mockZoom).toHaveBeenCalledWith('fit-viewport', 'auto')
   })
 
-  it('creates a blank diagram when no file path is provided', async () => {
-    const wrapper = mount(BpmnModeler, {})
+  it('applies 0.92 zoom factor after fit-viewport', async () => {
+    mockZoom.mockReturnValue(1.0)
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    expect(mockZoom).toHaveBeenCalledWith(expect.any(Number), 'auto')
+    const zoomCalls = mockZoom.mock.calls
+    const secondZoomArg = zoomCalls[zoomCalls.length - 1][0]
+    expect(secondZoomArg).toBeCloseTo(0.92, 1)
+  })
+
+  it('shows edit button after successful load', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    const button = wrapper.find('button[title="Open modeler"]')
+    expect(button.exists()).toBe(true)
+    expect(button.text()).toContain('Edit')
+  })
+
+  it('hides edit button while loading', () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
+    expect(wrapper.find('button[title="Open modeler"]').exists()).toBe(false)
+  })
+
+  it('creates blank diagram via temp modeler when no file path provided', async () => {
+    const wrapper = mount(BpmnModelerComponent, {})
     giveContainerDimensions(wrapper)
 
     await new Promise(resolve => setTimeout(resolve, 50))
     await flushPromises()
 
     expect(mockCreateDiagram).toHaveBeenCalled()
-    expect(mockImportXML).not.toHaveBeenCalled()
-    expect(mockResized).toHaveBeenCalled()
-    expect(mockZoom).toHaveBeenCalledWith('fit-viewport', 'auto')
+    expect(MockBpmnViewer).toHaveBeenCalled()
   })
 
   it('shows error when container dimensions timeout', async () => {
     vi.useFakeTimers()
     mockFetchSuccess()
-    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
 
     await vi.advanceTimersByTimeAsync(6000)
     await flushPromises()
@@ -145,49 +200,26 @@ describe('BpmnModeler.vue', () => {
 
   it('prevents duplicate rendering', async () => {
     mockFetchSuccess()
-    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
     giveContainerDimensions(wrapper)
 
     await new Promise(resolve => setTimeout(resolve, 50))
     await flushPromises()
 
-    const callCountAfterMount = MockBpmnModeler.mock.calls.length
+    const callCountAfterMount = MockBpmnViewer.mock.calls.length
 
-    // Trigger onSlideEnter — should NOT create another modeler
     const lastCallback = slideEnterCallbacks[slideEnterCallbacks.length - 1]
     if (lastCallback) {
       await lastCallback()
       await flushPromises()
     }
 
-    expect(MockBpmnModeler.mock.calls.length).toBe(callCountAfterMount)
-  })
-
-  it('allows retry after error', async () => {
-    vi.useFakeTimers()
-    mockFetchSuccess()
-    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
-
-    await vi.advanceTimersByTimeAsync(6000)
-    await flushPromises()
-
-    expect(wrapper.text()).toContain('Failed to load BPMN')
-
-    giveContainerDimensions(wrapper)
-
-    const lastCallback = slideEnterCallbacks[slideEnterCallbacks.length - 1]
-    if (lastCallback) {
-      await lastCallback()
-      await vi.advanceTimersByTimeAsync(100)
-      await flushPromises()
-    }
-
-    expect(mockImportXML).toHaveBeenCalled()
+    expect(MockBpmnViewer.mock.calls.length).toBe(callCountAfterMount)
   })
 
   it('shows error on fetch failure', async () => {
     mockFetchFailure()
-    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'missing.bpmn' } })
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'missing.bpmn' } })
     giveContainerDimensions(wrapper)
 
     await new Promise(resolve => setTimeout(resolve, 50))
@@ -196,22 +228,22 @@ describe('BpmnModeler.vue', () => {
     expect(wrapper.text()).toContain('Failed to load BPMN')
   })
 
-  it('destroys modeler on unmount', async () => {
+  it('destroys viewer on unmount', async () => {
     mockFetchSuccess()
-    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
     giveContainerDimensions(wrapper)
 
     await new Promise(resolve => setTimeout(resolve, 50))
     await flushPromises()
 
     wrapper.unmount()
-    expect(mockDestroy).toHaveBeenCalled()
+    expect(mockViewerDestroy).toHaveBeenCalled()
   })
 
   it('does not error on unmount before render completes', async () => {
     vi.useFakeTimers()
     mockFetchSuccess()
-    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
     expect(() => wrapper.unmount()).not.toThrow()
   })
 })

--- a/tests/components/BpmnModeler.test.ts
+++ b/tests/components/BpmnModeler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick } from 'vue'
 
 const { mockViewerDestroy, mockImportXML, mockResized, mockZoom, mockGet, MockBpmnViewer } = vi.hoisted(() => ({
   mockViewerDestroy: vi.fn(),
@@ -245,5 +246,91 @@ describe('BpmnModeler.vue', () => {
     mockFetchSuccess()
     const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
     expect(() => wrapper.unmount()).not.toThrow()
+  })
+
+  async function withModelerDimensions<T>(fn: () => Promise<T>): Promise<T> {
+    // Temporarily give all HTMLElements dimensions so waitForContainer resolves
+    // for the teleported modeler container (which has no layout in jsdom)
+    const origClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+    const origClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight')
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { get: () => 1200, configurable: true })
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { get: () => 800, configurable: true })
+    try {
+      return await fn()
+    } finally {
+      if (origClientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', origClientWidth)
+      if (origClientHeight) Object.defineProperty(HTMLElement.prototype, 'clientHeight', origClientHeight)
+    }
+  }
+
+  it('edit button click opens fullscreen modeler', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    MockBpmnModeler.mockClear()
+    mockImportXML.mockClear()
+
+    await withModelerDimensions(() => (wrapper.vm as any).openFullscreen())
+
+    expect(MockBpmnModeler).toHaveBeenCalled()
+    expect(mockImportXML).toHaveBeenCalledWith('<definitions></definitions>')
+  })
+
+  it('close button saves XML and re-renders viewer when changes were made', async () => {
+    let commandStackChangedCallback: (() => void) | null = null
+    mockGet.mockImplementation((service: string) => {
+      if (service === 'eventBus') {
+        return { on: (_event: string, cb: () => void) => { commandStackChangedCallback = cb } }
+      }
+      return { resized: mockResized, zoom: mockZoom, on: vi.fn() }
+    })
+
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    await withModelerDimensions(() => (wrapper.vm as any).openFullscreen())
+
+    expect(commandStackChangedCallback).not.toBeNull()
+
+    // Simulate a diagram change and close the modeler
+    mockSaveXML.mockResolvedValue({ xml: '<definitions>changed</definitions>' })
+    commandStackChangedCallback!()
+
+    mockImportXML.mockClear()
+    await (wrapper.vm as any).closeFullscreen()
+    await flushPromises()
+
+    expect(mockSaveXML).toHaveBeenCalled()
+    expect(mockModelerDestroy).toHaveBeenCalled()
+    expect(mockImportXML).toHaveBeenCalledWith('<definitions>changed</definitions>')
+  })
+
+  it('close button skips saveXML when no changes were made', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    await withModelerDimensions(() => (wrapper.vm as any).openFullscreen())
+
+    mockSaveXML.mockClear()
+    mockImportXML.mockClear()
+
+    await (wrapper.vm as any).closeFullscreen()
+    await flushPromises()
+
+    expect(mockSaveXML).not.toHaveBeenCalled()
+    expect(mockModelerDestroy).toHaveBeenCalled()
+    expect(mockImportXML).not.toHaveBeenCalled()
   })
 })

--- a/tests/components/BpmnModeler.test.ts
+++ b/tests/components/BpmnModeler.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const { mockDestroy, mockImportXML, mockCreateDiagram, mockResized, mockZoom, mockGet, MockBpmnModeler } = vi.hoisted(() => ({
+  mockDestroy: vi.fn(),
+  mockImportXML: vi.fn(),
+  mockCreateDiagram: vi.fn(),
+  mockResized: vi.fn(),
+  mockZoom: vi.fn(),
+  mockGet: vi.fn(),
+  MockBpmnModeler: vi.fn(),
+}))
+
+vi.mock('bpmn-js/lib/Modeler', () => ({
+  default: MockBpmnModeler,
+}))
+
+vi.mock('bpmn-js/dist/assets/bpmn-js.css', () => ({}))
+vi.mock('bpmn-js/dist/assets/diagram-js.css', () => ({}))
+
+const { slideEnterCallbacks } = vi.hoisted(() => ({
+  slideEnterCallbacks: [] as Array<() => void>,
+}))
+
+vi.mock('@slidev/client', () => ({
+  onSlideEnter: vi.fn((cb: () => void) => {
+    slideEnterCallbacks.push(cb)
+  }),
+}))
+
+import BpmnModeler from '../../components/BpmnModeler.vue'
+
+function mockFetchSuccess(xml = '<definitions></definitions>') {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(xml),
+  }))
+}
+
+function mockFetchFailure() {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: false,
+    status: 404,
+  }))
+}
+
+function giveContainerDimensions(wrapper: ReturnType<typeof mount>) {
+  const containerEl = wrapper.find('div[style*="calc"]').element as HTMLDivElement
+  if (containerEl) {
+    Object.defineProperty(containerEl, 'clientWidth', { value: 800, configurable: true })
+    Object.defineProperty(containerEl, 'clientHeight', { value: 500, configurable: true })
+  }
+}
+
+describe('BpmnModeler.vue', () => {
+  beforeEach(() => {
+    slideEnterCallbacks.length = 0
+    mockDestroy.mockClear()
+    mockImportXML.mockClear()
+    mockCreateDiagram.mockClear()
+    mockResized.mockClear()
+    mockZoom.mockClear()
+    mockGet.mockClear()
+    MockBpmnModeler.mockClear()
+
+    mockImportXML.mockResolvedValue(undefined)
+    mockCreateDiagram.mockResolvedValue(undefined)
+    mockGet.mockReturnValue({ resized: mockResized, zoom: mockZoom })
+    MockBpmnModeler.mockImplementation(function () {
+      return {
+        importXML: mockImportXML,
+        createDiagram: mockCreateDiagram,
+        destroy: mockDestroy,
+        get: mockGet,
+      }
+    })
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('shows loading state initially', () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    expect(wrapper.text()).toContain('Loading BPMN modeler...')
+  })
+
+  it('defaults containerHeight to 500px', () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    const outerDiv = wrapper.find('div').element as HTMLDivElement
+    expect(outerDiv.style.height).toBe('500px')
+  })
+
+  it('uses provided height for containerHeight', () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModeler, {
+      props: { bpmnFilePath: 'test.bpmn', height: '700px' },
+    })
+    const outerDiv = wrapper.find('div').element as HTMLDivElement
+    expect(outerDiv.style.height).toBe('700px')
+  })
+
+  it('renders with a file path when container has dimensions', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    expect(mockImportXML).toHaveBeenCalled()
+    expect(mockCreateDiagram).not.toHaveBeenCalled()
+    expect(mockResized).toHaveBeenCalled()
+    expect(mockZoom).toHaveBeenCalledWith('fit-viewport', 'auto')
+  })
+
+  it('creates a blank diagram when no file path is provided', async () => {
+    const wrapper = mount(BpmnModeler, {})
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    expect(mockCreateDiagram).toHaveBeenCalled()
+    expect(mockImportXML).not.toHaveBeenCalled()
+    expect(mockResized).toHaveBeenCalled()
+    expect(mockZoom).toHaveBeenCalledWith('fit-viewport', 'auto')
+  })
+
+  it('shows error when container dimensions timeout', async () => {
+    vi.useFakeTimers()
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+
+    await vi.advanceTimersByTimeAsync(6000)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Container dimensions not available within timeout')
+  })
+
+  it('prevents duplicate rendering', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    const callCountAfterMount = MockBpmnModeler.mock.calls.length
+
+    // Trigger onSlideEnter — should NOT create another modeler
+    const lastCallback = slideEnterCallbacks[slideEnterCallbacks.length - 1]
+    if (lastCallback) {
+      await lastCallback()
+      await flushPromises()
+    }
+
+    expect(MockBpmnModeler.mock.calls.length).toBe(callCountAfterMount)
+  })
+
+  it('allows retry after error', async () => {
+    vi.useFakeTimers()
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+
+    await vi.advanceTimersByTimeAsync(6000)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Failed to load BPMN')
+
+    giveContainerDimensions(wrapper)
+
+    const lastCallback = slideEnterCallbacks[slideEnterCallbacks.length - 1]
+    if (lastCallback) {
+      await lastCallback()
+      await vi.advanceTimersByTimeAsync(100)
+      await flushPromises()
+    }
+
+    expect(mockImportXML).toHaveBeenCalled()
+  })
+
+  it('shows error on fetch failure', async () => {
+    mockFetchFailure()
+    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'missing.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Failed to load BPMN')
+  })
+
+  it('destroys modeler on unmount', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    wrapper.unmount()
+    expect(mockDestroy).toHaveBeenCalled()
+  })
+
+  it('does not error on unmount before render completes', async () => {
+    vi.useFakeTimers()
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModeler, { props: { bpmnFilePath: 'test.bpmn' } })
+    expect(() => wrapper.unmount()).not.toThrow()
+  })
+})

--- a/tests/components/BpmnTokenSimulation.test.ts
+++ b/tests/components/BpmnTokenSimulation.test.ts
@@ -64,11 +64,13 @@ describe('BpmnTokenSimulation.vue', () => {
 
     mockImportXML.mockResolvedValue(undefined)
     mockGet.mockReturnValue({ resized: mockResized, zoom: mockZoom })
-    MockBpmnViewer.mockImplementation(() => ({
-      importXML: mockImportXML,
-      destroy: mockDestroy,
-      get: mockGet,
-    }))
+    MockBpmnViewer.mockImplementation(function () {
+      return {
+        importXML: mockImportXML,
+        destroy: mockDestroy,
+        get: mockGet,
+      }
+    })
 
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,5 @@
 import.meta.env.BASE_URL = '/'
+
+// vitest 4.x with jsdom does not auto-advance requestAnimationFrame in real-timer mode.
+// Replace it with an immediate setTimeout so component polling resolves in tests.
+global.requestAnimationFrame = (cb) => setTimeout(cb, 0) as unknown as number

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       'bpmn-js/lib/Viewer',
+      'bpmn-js/lib/Modeler',
       'bpmn-js-token-simulation/lib/viewer',
     ],
   },


### PR DESCRIPTION
## Summary
- Add new `BpmnModeler` component embedding the bpmn-js modeler for live diagram editing in presentations
- Supports loading existing `.bpmn` files or starting with a blank canvas (single start event)
- Ideal for workshops, trainings, and collaborative sessions where diagrams are built step by step
- Updated `vite.config.ts` with modeler dependency optimization
- Added example slides and updated docs

Closes #12

## Test plan
- [ ] Run `npm run dev` and verify modeler slides load with palette visible
- [ ] Test editing an existing diagram (drag elements, add connections)
- [ ] Test blank canvas creation (should show a single start event)
- [ ] Verify existing Bpmn and BpmnTokenSimulation slides still work
- [ ] Run `npm run build` to confirm build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)