### PR TITLE
chore: fix dark background and open browser on dev

### DIFF
--- a/example.md
+++ b/example.md
@@ -1,3 +1,7 @@
+---
+colorSchema: light
+---
+
 <style>
 h1 {
   color: #335DE4;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Display BPMN 2.0 diagrams in Slidev presentations",
   "type": "module",
   "scripts": {
-    "dev": "portless run sh -c 'npx slidev example.md --port $PORT --remote --bind 127.0.0.1'",
+    "dev": "portless run sh -c 'npx slidev example.md --port $PORT --remote --bind 127.0.0.1 --open'",
     "build": "slidev build example.md",
     "export": "slidev export example.md",
     "screenshot": "slidev export example.md --format png",


### PR DESCRIPTION
## Summary
- Add `colorSchema: light` to `example.md` frontmatter to prevent the OS dark mode from making all slides black
- Add `--open` flag to the `dev` script so the browser opens automatically on `npm run dev`

## Test plan
- [ ] Run `npm run dev` and verify the browser opens automatically
- [ ] Verify slides render with a white background regardless of system dark mode setting