### PR TITLE
feat: add engine prop to BpmnModeler for Zeebe and Camunda 7 properties panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ dist/
 
 .DS_Store
 .claude/settings.local.json
+.claude/logs/
 .context/
+.gstack/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ The addon provides three Vue components:
 
 - **`Bpmn.vue`** — Static SVG rendering (off-screen render approach, best for PDF exports)
 - **`BpmnTokenSimulation.vue`** — Interactive viewer with animated token flow simulation
-- **`BpmnModeler.vue`** — Interactive BPMN modeler for live diagram editing (workshops/trainings)
+- **`BpmnModeler.vue`** — Interactive BPMN modeler for live diagram editing (workshops/trainings). Accepts an optional `engine` prop (`"zeebe"` | `"camunda7"`) that mounts an engine-specific properties panel side-by-side with the canvas. Engine wiring lives in `engines/zeebe.ts` and `engines/camunda7.ts` — one file per engine (SRP); the component picks one via a small `if` in `resolveEngineConfig()`. Adding a new engine = one new file under `engines/` plus one `if` line.
 
 #### Bpmn.vue (Static Viewer)
 
@@ -58,6 +58,7 @@ The `vite.config.ts` file is **critical** for this addon to work. It includes bp
 The npm package includes only:
 - `components/` directory (Bpmn.vue, BpmnTokenSimulation.vue, BpmnModeler.vue)
 - `composables/` directory (useBpmn.ts)
+- `engines/` directory (types.ts, zeebe.ts, camunda7.ts)
 - `vite.config.ts` (required Vite configuration)
 
 Everything else (`example.md`, `public/`, `docs/`) is excluded via the `files` field in package.json.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This addon provides three complementary components for different use cases:
 
 - **`<Bpmn>`** - Static BPMN rendering for PDFs, presentations, and documentation
 - **`<BpmnTokenSimulation>`** - Interactive token-based process simulation for live demos
-- **`<BpmnModeler>`** - Interactive BPMN modeler for live diagram editing during workshops and trainings
+- **`<BpmnModeler>`** - Interactive BPMN modeler for live diagram editing during workshops and trainings, with optional Zeebe / Camunda 7 properties panel
 
 ## 🔧 Component Reference
 
@@ -115,6 +115,18 @@ Or start with a blank canvas (a single start event):
 <BpmnModeler height="500px" />
 ```
 
+Pass an `engine` to mount an engine-specific properties panel side-by-side with the canvas, so you can edit Zeebe `taskDefinition`s, Camunda 7 expressions, message names, and other technical attributes live:
+
+```vue
+<!-- Camunda 8 / Zeebe -->
+<BpmnModeler bpmnFilePath="./my-process.bpmn" engine="zeebe" height="500px" />
+
+<!-- Camunda 7 / Platform -->
+<BpmnModeler bpmnFilePath="./my-process.bpmn" engine="camunda7" height="500px" />
+```
+
+In fullscreen mode, the panel can be hidden and shown again via the toolbar — handy when you need the full canvas width.
+
 **Props:**
 
 | Name | Type | Default | Description |
@@ -122,6 +134,7 @@ Or start with a blank canvas (a single start event):
 | `bpmnFilePath` | `string` | — | Optional path to a `.bpmn` file (relative to `public/`). Omit for a blank diagram. |
 | `width` | `string` | `'100%'` | Width of the modeler container |
 | `height` | `string` | `'500px'` | Height of the modeler container |
+| `engine` | `'zeebe' \| 'camunda7'` | — | Optional engine. Mounts a `bpmn-js-properties-panel` configured for the chosen engine. Omit for a panel-less modeler. |
 
 ## 💡 Tips
 

--- a/components/BpmnModeler.vue
+++ b/components/BpmnModeler.vue
@@ -49,10 +49,22 @@
           height: '100vh',
           zIndex: 9999,
           background: 'white',
+          display: 'flex',
         }"
         @keydown.stop
       >
-        <div ref="modelerContainerRef" :style="{ width: '100%', height: '100%' }"></div>
+        <div ref="modelerContainerRef" :style="{ flex: 1, height: '100%' }"></div>
+        <div
+          v-if="props.engine"
+          ref="propertiesPanelRef"
+          :style="{
+            width: '350px',
+            height: '100%',
+            overflowY: 'auto',
+            borderLeft: '1px solid #ccc',
+            background: '#fafafa',
+          }"
+        ></div>
 
         <button
           :style="{
@@ -94,8 +106,12 @@ import BpmnModeler from 'bpmn-js/lib/Modeler'
 import 'bpmn-js/dist/assets/bpmn-js.css'
 import 'bpmn-js/dist/assets/diagram-js.css'
 import 'bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css'
+import '@bpmn-io/properties-panel/dist/assets/properties-panel.css'
 import { onSlideEnter } from '@slidev/client'
 import { useBpmn } from '../composables/useBpmn'
+import { zeebeEngine } from '../engines/zeebe'
+import { camunda7Engine } from '../engines/camunda7'
+import type { Engine } from '../engines/types'
 
 const margin = 5
 const containerWaitTimeout = 5000
@@ -103,6 +119,7 @@ const containerWaitTimeout = 5000
 const { loading, error, fetchBpmnXml, withLoading } = useBpmn()
 const viewerContainerRef = ref<HTMLDivElement | null>(null)
 const modelerContainerRef = ref<HTMLDivElement | null>(null)
+const propertiesPanelRef = ref<HTMLDivElement | null>(null)
 const isRendered = ref(false)
 const isFullscreen = ref(false)
 const currentXml = ref<string | null>(null)
@@ -114,10 +131,17 @@ const props = withDefaults(defineProps<{
   bpmnFilePath?: string
   width?: string
   height?: string
+  engine?: Engine
 }>(), {
   width: '100%',
   height: '500px',
 })
+
+function resolveEngineConfig() {
+  if (props.engine === 'zeebe') return zeebeEngine
+  if (props.engine === 'camunda7') return camunda7Engine
+  return null
+}
 
 const containerHeight = props.height
 
@@ -189,7 +213,15 @@ async function openFullscreen() {
   await waitForContainer(modelerContainerRef)
 
   hasModelerChanges = false
-  modeler = new BpmnModeler({ container: modelerContainerRef.value! })
+
+  const config = resolveEngineConfig()
+  const options: any = { container: modelerContainerRef.value! }
+  if (config) {
+    options.propertiesPanel = { parent: propertiesPanelRef.value! }
+    options.additionalModules = config.additionalModules
+    options.moddleExtensions = config.moddleExtensions
+  }
+  modeler = new BpmnModeler(options)
 
   await modeler.importXML(currentXml.value!)
 

--- a/components/BpmnModeler.vue
+++ b/components/BpmnModeler.vue
@@ -53,9 +53,50 @@
         }"
         @keydown.stop
       >
-        <div ref="modelerContainerRef" :style="{ flex: 1, height: '100%' }"></div>
+        <div :style="{ flex: 1, height: '100%', position: 'relative' }">
+          <div ref="modelerContainerRef" :style="{ width: '100%', height: '100%' }"></div>
+
+          <div :style="{
+            position: 'absolute',
+            top: '16px',
+            right: '16px',
+            zIndex: 10000,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'stretch',
+            gap: '8px',
+          }">
+            <button
+              :style="toolbarBtnStyle"
+              title="Close modeler"
+              @click="closeFullscreen"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/>
+                <line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+              Close
+            </button>
+            <button
+              v-if="props.engine"
+              :style="toolbarBtnStyle"
+              :title="isPanelOpen ? 'Hide properties panel' : 'Show properties panel'"
+              @click="togglePanel"
+            >
+              <svg v-if="isPanelOpen" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="9 18 15 12 9 6"/>
+              </svg>
+              <svg v-else xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="15 18 9 12 15 6"/>
+              </svg>
+              {{ isPanelOpen ? 'Hide panel' : 'Show panel' }}
+            </button>
+          </div>
+        </div>
+
         <div
           v-if="props.engine"
+          v-show="isPanelOpen"
           ref="propertiesPanelRef"
           :style="{
             width: '350px',
@@ -65,34 +106,6 @@
             background: '#fafafa',
           }"
         ></div>
-
-        <button
-          :style="{
-            position: 'absolute',
-            top: '16px',
-            right: '16px',
-            zIndex: 10000,
-            cursor: 'pointer',
-            background: 'white',
-            border: '1px solid #ccc',
-            borderRadius: '4px',
-            padding: '6px 8px',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '4px',
-            fontSize: '13px',
-            color: '#333',
-            boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-          }"
-          title="Close modeler"
-          @click="closeFullscreen"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"/>
-            <line x1="6" y1="6" x2="18" y2="18"/>
-          </svg>
-          Close
-        </button>
       </div>
     </Teleport>
   </div>
@@ -116,12 +129,27 @@ import type { Engine } from '../engines/types'
 const margin = 5
 const containerWaitTimeout = 5000
 
+const toolbarBtnStyle = {
+  cursor: 'pointer',
+  background: 'white',
+  border: '1px solid #ccc',
+  borderRadius: '4px',
+  padding: '6px 8px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  fontSize: '13px',
+  color: '#333',
+  boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+}
+
 const { loading, error, fetchBpmnXml, withLoading } = useBpmn()
 const viewerContainerRef = ref<HTMLDivElement | null>(null)
 const modelerContainerRef = ref<HTMLDivElement | null>(null)
 const propertiesPanelRef = ref<HTMLDivElement | null>(null)
 const isRendered = ref(false)
 const isFullscreen = ref(false)
+const isPanelOpen = ref(true)
 const currentXml = ref<string | null>(null)
 let viewer: InstanceType<typeof BpmnViewer> | null = null
 let modeler: InstanceType<typeof BpmnModeler> | null = null
@@ -243,6 +271,7 @@ async function closeFullscreen() {
   }
 
   isFullscreen.value = false
+  isPanelOpen.value = true
 
   if (hasModelerChanges) {
     await nextTick()
@@ -250,7 +279,16 @@ async function closeFullscreen() {
   }
 }
 
-defineExpose({ openFullscreen, closeFullscreen })
+async function togglePanel() {
+  isPanelOpen.value = !isPanelOpen.value
+  await nextTick()
+  if (modeler) {
+    const canvas = modeler.get('canvas') as any
+    canvas.resized()
+  }
+}
+
+defineExpose({ openFullscreen, closeFullscreen, togglePanel })
 
 onMounted(async () => {
   await nextTick()

--- a/engines/camunda7.ts
+++ b/engines/camunda7.ts
@@ -1,0 +1,16 @@
+import {
+  BpmnPropertiesPanelModule,
+  BpmnPropertiesProviderModule,
+  CamundaPlatformPropertiesProviderModule,
+} from 'bpmn-js-properties-panel'
+import camundaModdle from 'camunda-bpmn-moddle/resources/camunda.json'
+import type { EngineConfig } from './types'
+
+export const camunda7Engine: EngineConfig = {
+  additionalModules: [
+    BpmnPropertiesPanelModule,
+    BpmnPropertiesProviderModule,
+    CamundaPlatformPropertiesProviderModule,
+  ],
+  moddleExtensions: { camunda: camundaModdle },
+}

--- a/engines/types.ts
+++ b/engines/types.ts
@@ -1,0 +1,6 @@
+export type Engine = 'zeebe' | 'camunda7'
+
+export interface EngineConfig {
+  additionalModules: any[]
+  moddleExtensions: Record<string, any>
+}

--- a/engines/zeebe.ts
+++ b/engines/zeebe.ts
@@ -1,0 +1,18 @@
+import {
+  BpmnPropertiesPanelModule,
+  BpmnPropertiesProviderModule,
+  ZeebePropertiesProviderModule,
+} from 'bpmn-js-properties-panel'
+import ZeebeBehaviorsModule from 'camunda-bpmn-js-behaviors/lib/camunda-cloud'
+import zeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json'
+import type { EngineConfig } from './types'
+
+export const zeebeEngine: EngineConfig = {
+  additionalModules: [
+    BpmnPropertiesPanelModule,
+    BpmnPropertiesProviderModule,
+    ZeebePropertiesProviderModule,
+    ZeebeBehaviorsModule,
+  ],
+  moddleExtensions: { zeebe: zeebeModdle },
+}

--- a/example.md
+++ b/example.md
@@ -61,7 +61,7 @@ The `BpmnTokenSimulation` component adds animated token flow for process demonst
 
 Pass `engine="zeebe"` and you get a full properties panel with Zeebe extensions – task definitions, headers, subscriptions, the whole Klumpatsch! Perfekt for workshops targeting Camunda 8 where executable details matter just as much as the shape.
 
-<BpmnModeler bpmnFilePath="./newsletter.bpmn" engine="zeebe" height="400px"></BpmnModeler>
+<BpmnModeler bpmnFilePath="./newsletter.bpmn" engine="zeebe" height="320px"></BpmnModeler>
 
 ---
 
@@ -69,7 +69,7 @@ Pass `engine="zeebe"` and you get a full properties panel with Zeebe extensions 
 
 Für die Camunda-7-Fraktion: `engine="camunda7"` swaps in the Camunda Platform properties panel, so you can wire up expressions, delegate beans and assignees live – ganz ohne Tool-Hopserei.
 
-<BpmnModeler bpmnFilePath="./loan-approval.bpmn" engine="camunda7" height="400px"></BpmnModeler>
+<BpmnModeler bpmnFilePath="./loan-approval.bpmn" engine="camunda7" height="320px"></BpmnModeler>
 
 ---
 
@@ -77,4 +77,4 @@ Für die Camunda-7-Fraktion: `engine="camunda7"` swaps in the Camunda Platform p
 
 No `engine` prop? Dann gibt's nur die Zeichenfläche – a bare modeler for pure structural modeling. Ideal for live sessions where you build a process from scratch with your audience.
 
-<BpmnModeler height="400px"></BpmnModeler>
+<BpmnModeler height="320px"></BpmnModeler>

--- a/example.md
+++ b/example.md
@@ -57,16 +57,24 @@ The `BpmnTokenSimulation` component adds animated token flow for process demonst
 
 ---
 
-## Interactive BPMN Modeler
+## Zeebe Modeler (Camunda 8)
 
-The `BpmnModeler` component embeds a full BPMN editor – jetzt kannst du live in der Präsentation modellieren, so richtig gscheid! Perfect for workshops and trainings where you build diagrams step by step with your audience.
+Pass `engine="zeebe"` and you get a full properties panel with Zeebe extensions – task definitions, headers, subscriptions, the whole Klumpatsch! Perfekt for workshops targeting Camunda 8 where executable details matter just as much as the shape.
 
-<BpmnModeler bpmnFilePath="./newsletter.bpmn" height="400px"></BpmnModeler>
+<BpmnModeler bpmnFilePath="./newsletter.bpmn" engine="zeebe" height="400px"></BpmnModeler>
+
+---
+
+## Camunda 7 Modeler
+
+Für die Camunda-7-Fraktion: `engine="camunda7"` swaps in the Camunda Platform properties panel, so you can wire up expressions, delegate beans and assignees live – ganz ohne Tool-Hopserei.
+
+<BpmnModeler bpmnFilePath="./loan-approval.bpmn" engine="camunda7" height="400px"></BpmnModeler>
 
 ---
 
 ## Blank Canvas Modeler
 
-Start from scratch with a blank diagram – just a single start event to get you going. Ideal for live modeling sessions where you build a process together with your audience!
+No `engine` prop? Dann gibt's nur die Zeichenfläche – a bare modeler for pure structural modeling. Ideal for live sessions where you build a process from scratch with your audience.
 
 <BpmnModeler height="400px"></BpmnModeler>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,13 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
+        "@bpmn-io/properties-panel": "3.41.1",
         "bpmn-js": "18.14.0",
-        "bpmn-js-token-simulation": "0.39.3"
+        "bpmn-js-properties-panel": "5.54.0",
+        "bpmn-js-token-simulation": "0.39.3",
+        "camunda-bpmn-js-behaviors": "1.14.1",
+        "camunda-bpmn-moddle": "7.0.1",
+        "zeebe-bpmn-moddle": "1.13.0"
       },
       "devDependencies": {
         "@slidev/cli": "52.14.2",
@@ -549,6 +554,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bpmn-io/cm-theme": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.3.1",
+        "@codemirror/view": "^6.5.1",
+        "@lezer/highlight": "^1.1.4"
+      },
+      "workspaces": {
+        "packages": [
+          "preview-themes"
+        ]
+      }
+    },
     "node_modules/@bpmn-io/diagram-js-ui": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
@@ -557,6 +578,120 @@
       "dependencies": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
+      }
+    },
+    "node_modules/@bpmn-io/extract-process-variables": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-2.2.1.tgz",
+      "integrity": "sha512-1E5ydNzTqgx513NxA1nxk2CqDb9OkusfU9Tf6WejD1BiY+5u130XnZOFE/FQX0JB6ZmPOeFMx4IDEuHjrGhOzw==",
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0"
+      }
+    },
+    "node_modules/@bpmn-io/feel-editor": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.5.2.tgz",
+      "integrity": "sha512-pxbhUDAlLe+zDAvmG7Y057o8rnVImKYEbgjH4+zZiq3WjPw5bZYu2kraJfpWMs3xkyOCvLR6H3J3f8yJRuHmgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feel-lint": "^3.1.0",
+        "@bpmn-io/lang-feel": "^3.0.0",
+        "@camunda/feel-builtins": "^1.0.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.2",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/lint": "^6.9.3",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.13",
+        "@lezer/highlight": "^1.2.3",
+        "min-dom": "^5.2.0",
+        "mitt": "^3.0.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@bpmn-io/feel-lint": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-3.1.0.tgz",
+      "integrity": "sha512-nOCYWMXgwR0joU4XKhu4f3P5f4/AsmuyiV1e+fzcXTCh7iMLU8VYdHXSIzZuJ0zxz3Gsnp7A8S8lt+HJ43H6IA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@codemirror/language": "^6.12.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@bpmn-io/feelin": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feelin/-/feelin-6.1.0.tgz",
+      "integrity": "sha512-nqmmlHRD9tl0ZcpYTEkZdpc/rAMoYc+ct0SOg9fFIFWRaEApme3DuXC7v9AMA5g+upGCKd6cUc3t97y+unpfMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@lezer/common": "^1.5.0",
+        "luxon": "^3.7.2",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/lang-feel": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-3.0.0.tgz",
+      "integrity": "sha512-t/k0z5AW18J7Qz2i/bIFAlvlcS63RuyQB9OQ0YiC1WyMosxXRAnv98LHnVbwirx9vje1DLll85tkBT2B8KLjmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^2.0.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/language": "^6.11.3",
+        "@lezer/common": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/lezer-feel": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.4.0.tgz",
+      "integrity": "sha512-V6L6p7GZSQnpNld1RKlk9A2GYmKoK3f1Qnzcay58ei/OGYDUHCl+267ldhe9LRmlFUr5emp5MSvjG2ekkXdwtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.8",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/properties-panel": {
+      "version": "3.41.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.41.1.tgz",
+      "integrity": "sha512-p8Y+w0IINjnJo1XmcgBjWMM0VRpsfvc87gaCUDQipo89V1DGduwk5Nl6xsJGXrNtE7s2jUdbtK4xdReMMOAPHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feel-editor": "^2.5.2",
+        "@carbon/icons": "^11.69.0",
+        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/language": "^6.11.0",
+        "@codemirror/lint": "^6.9.5",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.28.1",
+        "classnames": "^2.5.1",
+        "feelers": "^1.5.1",
+        "focus-trap": "^8.0.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -577,6 +712,22 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@camunda/feel-builtins": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.2.0.tgz",
+      "integrity": "sha512-dtfv9TSDiTEivARL2l8qawxsQi9BBajoSUQQIlVXVBwt5rp/FQ9UD2DTzki//RnLnu2V2O69SxGZDhWTT28qQg==",
+      "license": "MIT"
+    },
+    "node_modules/@carbon/icons": {
+      "version": "11.79.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.79.0.tgz",
+      "integrity": "sha512-VNYZQkf2z53R0IRotCAq0n+GrSw59el/Ts/uabg4LUt4akFpbS+EBblsHQmT/LuBDoaTsRq2d06AidTz2iv4uA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
@@ -620,6 +771,86 @@
       "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
+      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "node_modules/@comark/markdown-it": {
       "version": "0.3.0",
@@ -1312,6 +1543,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ibm/telemetry-js": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.11.0.tgz",
+      "integrity": "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "ibmtelemetry": "dist/collect.js"
+      }
+    },
     "node_modules/@iconify-json/carbon": {
       "version": "1.2.20",
       "resolved": "https://registry.npmjs.org/@iconify-json/carbon/-/carbon-1.2.20.tgz",
@@ -1508,6 +1748,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
     "node_modules/@lillallol/outline-pdf": {
       "version": "4.0.0",
       "dev": true,
@@ -1520,6 +1805,12 @@
     "node_modules/@lillallol/outline-pdf-data-structure": {
       "version": "1.0.3",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
     "node_modules/@mdit-vue/plugin-component": {
@@ -4628,6 +4919,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-move": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-4.0.0.tgz",
+      "integrity": "sha512-+RY54S8OuVvg94THpneQvFRmqWdAHeqtMzgMW6JNurHxe8rsS07cHQdfGkXnTUXiBcyZ0j3SiDIxxj0RPiqCkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4742,6 +5045,28 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/bpmn-js-properties-panel": {
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.54.0.tgz",
+      "integrity": "sha512-CHmIWweeZrIZrmdn3R2cFp4PInxxirVgn5U4kXeF8+IKenZ33aVivVddjuh+02H9JwmOSDblC0vgUIS+HNbSVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/extract-process-variables": "^2.2.1",
+        "array-move": "^4.0.0",
+        "ids": "^3.0.2",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "@bpmn-io/properties-panel": ">= 3.40.6",
+        "bpmn-js": ">= 11.5",
+        "camunda-bpmn-js-behaviors": ">= 0.4",
+        "diagram-js": ">= 11.9"
       }
     },
     "node_modules/bpmn-js-token-simulation": {
@@ -4899,6 +5224,27 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/camunda-bpmn-js-behaviors": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.14.1.tgz",
+      "integrity": "sha512-M+awrL4PuKFi8kemtjLV8A32zODVQ2/cLuaHl2lZt5EKmMjxGb41BL3ulDRaK1Je712/zFTliYKNDX3IsLAvpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ids": "^3.0.1",
+        "min-dash": "^5.0.0"
+      },
+      "peerDependencies": {
+        "bpmn-js": ">= 9",
+        "camunda-bpmn-moddle": ">= 7",
+        "zeebe-bpmn-moddle": ">= 0.18"
+      }
+    },
+    "node_modules/camunda-bpmn-moddle": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
+      "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ==",
+      "license": "MIT"
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001788",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
@@ -5027,6 +5373,12 @@
       "dependencies": {
         "consola": "^3.2.3"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/cli-progress": {
       "version": "3.12.0",
@@ -5285,6 +5637,12 @@
       "dependencies": {
         "layout-base": "^1.0.0"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6516,6 +6874,37 @@
         }
       }
     },
+    "node_modules/feelers": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/feelers/-/feelers-1.5.1.tgz",
+      "integrity": "sha512-LKIAqtScSfy55Tw62DhBcxIT3k2XnppzWrkmGfsbdad0a+TxMfaLF1CSYhoVRF5FvPAUXvor1Ux/75wtBaDYpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
+        "@bpmn-io/feel-lint": "^3.1.0",
+        "@bpmn-io/feelin": "^6.1.0",
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.1",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/lint": "^6.9.3",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.12",
+        "@lezer/common": "^1.5.1",
+        "@lezer/highlight": "^1.1.6",
+        "@lezer/lr": "^1.4.8",
+        "@lezer/markdown": "^1.6.3",
+        "min-dom": "^5.2.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "workspaces": {
+        "packages": [
+          "feelers-playground"
+        ]
+      }
+    },
     "node_modules/file-saver": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
@@ -6584,6 +6973,15 @@
         "@nuxt/kit": {
           "optional": true
         }
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.0.1.tgz",
+      "integrity": "sha512-9ptSG6z51YQOstI/oN4XuVGP/03u2nh0g//qz7L6zX0i6PZiPnkcf3GenXq7N2hZnASXaMxTPpbKwdI+PFvxlw==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
       }
     },
     "node_modules/foreground-child": {
@@ -7564,6 +7962,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -8523,6 +8930,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.0",
@@ -9920,6 +10333,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-value-types": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.1.2.tgz",
@@ -9961,6 +10380,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/time-span": {
@@ -11260,6 +11685,12 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -11603,6 +12034,12 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/zeebe-bpmn-moddle": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.13.0.tgz",
+      "integrity": "sha512-F5IGMleZo48OG3Q20TTBdQmIcnVZSzBjizUq3WyNm0WwNzaKyeTXu3LBheOFuVtm//inEBArv/t7FGQD16yXdg==",
+      "license": "MIT"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,13 @@
   "author": "Marco Schäck (https://github.com/emaarco)",
   "license": "MIT",
   "dependencies": {
+    "@bpmn-io/properties-panel": "3.41.1",
     "bpmn-js": "18.14.0",
-    "bpmn-js-token-simulation": "0.39.3"
+    "bpmn-js-properties-panel": "5.54.0",
+    "bpmn-js-token-simulation": "0.39.3",
+    "camunda-bpmn-js-behaviors": "1.14.1",
+    "camunda-bpmn-moddle": "7.0.1",
+    "zeebe-bpmn-moddle": "1.13.0"
   },
   "devDependencies": {
     "@slidev/cli": "52.14.2",
@@ -40,6 +45,7 @@
   "files": [
     "components",
     "composables",
+    "engines",
     "vite.config.ts"
   ],
   "sideEffects": [

--- a/public/loan-approval.bpmn
+++ b/public/loan-approval.bpmn
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_LoanApproval" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="loan-approval" name="Loan Approval" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_LoanRequested" name="Loan&#10;requested">
+      <bpmn:outgoing>Flow_ToScore</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_ScoreApplicant" name="Score applicant" camunda:expression="${scoringService.score(applicantId)}" camunda:resultVariable="score">
+      <bpmn:incoming>Flow_ToScore</bpmn:incoming>
+      <bpmn:outgoing>Flow_ToDecision</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_Decision" name="Score&#10;ok?">
+      <bpmn:incoming>Flow_ToDecision</bpmn:incoming>
+      <bpmn:outgoing>Flow_Approved</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Rejected</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Activity_ApproveLoan" name="Approve loan" camunda:assignee="clerk">
+      <bpmn:incoming>Flow_Approved</bpmn:incoming>
+      <bpmn:outgoing>Flow_ToEndApproved</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_Approved" name="Loan&#10;approved">
+      <bpmn:incoming>Flow_ToEndApproved</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_Rejected" name="Loan&#10;rejected">
+      <bpmn:incoming>Flow_Rejected</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_ToScore" sourceRef="StartEvent_LoanRequested" targetRef="Activity_ScoreApplicant" />
+    <bpmn:sequenceFlow id="Flow_ToDecision" sourceRef="Activity_ScoreApplicant" targetRef="Gateway_Decision" />
+    <bpmn:sequenceFlow id="Flow_Approved" name="yes" sourceRef="Gateway_Decision" targetRef="Activity_ApproveLoan">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${score &gt;= 700}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Rejected" name="no" sourceRef="Gateway_Decision" targetRef="EndEvent_Rejected">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${score &lt; 700}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_ToEndApproved" sourceRef="Activity_ApproveLoan" targetRef="EndEvent_Approved" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="loan-approval">
+      <bpmndi:BPMNShape id="StartEvent_LoanRequested_di" bpmnElement="StartEvent_LoanRequested">
+        <dc:Bounds x="172" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="166" y="205" width="49" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_ScoreApplicant_di" bpmnElement="Activity_ScoreApplicant">
+        <dc:Bounds x="260" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_Decision_di" bpmnElement="Gateway_Decision" isMarkerVisible="true">
+        <dc:Bounds x="415" y="155" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="418" y="118" width="44" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_ApproveLoan_di" bpmnElement="Activity_ApproveLoan">
+        <dc:Bounds x="520" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Approved_di" bpmnElement="EndEvent_Approved">
+        <dc:Bounds x="682" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="205" width="49" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Rejected_di" bpmnElement="EndEvent_Rejected">
+        <dc:Bounds x="422" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="416" y="315" width="49" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_ToScore_di" bpmnElement="Flow_ToScore">
+        <di:waypoint x="208" y="180" />
+        <di:waypoint x="260" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_ToDecision_di" bpmnElement="Flow_ToDecision">
+        <di:waypoint x="360" y="180" />
+        <di:waypoint x="415" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Approved_di" bpmnElement="Flow_Approved">
+        <di:waypoint x="465" y="180" />
+        <di:waypoint x="520" y="180" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="484" y="162" width="17" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Rejected_di" bpmnElement="Flow_Rejected">
+        <di:waypoint x="440" y="205" />
+        <di:waypoint x="440" y="272" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="446" y="230" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_ToEndApproved_di" bpmnElement="Flow_ToEndApproved">
+        <di:waypoint x="620" y="180" />
+        <di:waypoint x="682" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/components/BpmnModeler.test.ts
+++ b/tests/components/BpmnModeler.test.ts
@@ -29,6 +29,20 @@ vi.mock('bpmn-js/lib/Modeler', () => ({
 vi.mock('bpmn-js/dist/assets/bpmn-js.css', () => ({}))
 vi.mock('bpmn-js/dist/assets/diagram-js.css', () => ({}))
 vi.mock('bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css', () => ({}))
+vi.mock('@bpmn-io/properties-panel/dist/assets/properties-panel.css', () => ({}))
+
+vi.mock('../../engines/zeebe', () => ({
+  zeebeEngine: {
+    additionalModules: ['zeebe-mod-a', 'zeebe-mod-b'],
+    moddleExtensions: { zeebe: { tag: 'zeebe-moddle' } },
+  },
+}))
+vi.mock('../../engines/camunda7', () => ({
+  camunda7Engine: {
+    additionalModules: ['c7-mod-a', 'c7-mod-b'],
+    moddleExtensions: { camunda: { tag: 'camunda-moddle' } },
+  },
+}))
 
 const { slideEnterCallbacks } = vi.hoisted(() => ({
   slideEnterCallbacks: [] as Array<() => void>,
@@ -332,5 +346,65 @@ describe('BpmnModeler.vue', () => {
     expect(mockSaveXML).not.toHaveBeenCalled()
     expect(mockModelerDestroy).toHaveBeenCalled()
     expect(mockImportXML).not.toHaveBeenCalled()
+  })
+
+  it('passes only { container } to the modeler when no engine prop is set', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    MockBpmnModeler.mockClear()
+    await withModelerDimensions(() => (wrapper.vm as any).openFullscreen())
+
+    const options = MockBpmnModeler.mock.calls[0][0]
+    expect(options).toHaveProperty('container')
+    expect(options).not.toHaveProperty('additionalModules')
+    expect(options).not.toHaveProperty('moddleExtensions')
+    expect(options).not.toHaveProperty('propertiesPanel')
+
+    expect(document.querySelector('[ref="propertiesPanelRef"]')).toBeNull()
+  })
+
+  it('engine="zeebe" wires Zeebe modules, moddle and a panel parent', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, {
+      props: { bpmnFilePath: 'test.bpmn', engine: 'zeebe' },
+    })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    MockBpmnModeler.mockClear()
+    await withModelerDimensions(() => (wrapper.vm as any).openFullscreen())
+
+    const options = MockBpmnModeler.mock.calls[0][0]
+    expect(options.additionalModules).toEqual(['zeebe-mod-a', 'zeebe-mod-b'])
+    expect(options.moddleExtensions).toEqual({ zeebe: { tag: 'zeebe-moddle' } })
+    expect(options.propertiesPanel).toBeDefined()
+    expect(options.propertiesPanel.parent).toBeInstanceOf(HTMLElement)
+  })
+
+  it('engine="camunda7" wires Camunda Platform modules, moddle and a panel parent', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, {
+      props: { bpmnFilePath: 'test.bpmn', engine: 'camunda7' },
+    })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    MockBpmnModeler.mockClear()
+    await withModelerDimensions(() => (wrapper.vm as any).openFullscreen())
+
+    const options = MockBpmnModeler.mock.calls[0][0]
+    expect(options.additionalModules).toEqual(['c7-mod-a', 'c7-mod-b'])
+    expect(options.moddleExtensions).toEqual({ camunda: { tag: 'camunda-moddle' } })
+    expect(options.propertiesPanel).toBeDefined()
+    expect(options.propertiesPanel.parent).toBeInstanceOf(HTMLElement)
   })
 })

--- a/tests/components/BpmnModeler.test.ts
+++ b/tests/components/BpmnModeler.test.ts
@@ -388,6 +388,25 @@ describe('BpmnModeler.vue', () => {
     expect(options.propertiesPanel.parent).toBeInstanceOf(HTMLElement)
   })
 
+  it('togglePanel flips isPanelOpen and triggers canvas.resized()', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, {
+      props: { bpmnFilePath: 'test.bpmn', engine: 'zeebe' },
+    })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    await withModelerDimensions(() => (wrapper.vm as any).openFullscreen())
+
+    mockResized.mockClear()
+    await (wrapper.vm as any).togglePanel()
+    await flushPromises()
+
+    expect(mockResized).toHaveBeenCalled()
+  })
+
   it('engine="camunda7" wires Camunda Platform modules, moddle and a panel parent', async () => {
     mockFetchSuccess()
     const wrapper = mount(BpmnModelerComponent, {

--- a/tests/engines/camunda7.test.ts
+++ b/tests/engines/camunda7.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('bpmn-js-properties-panel', () => ({
+  BpmnPropertiesPanelModule: { __id: 'panel' },
+  BpmnPropertiesProviderModule: { __id: 'provider' },
+  CamundaPlatformPropertiesProviderModule: { __id: 'c7-provider' },
+}))
+vi.mock('camunda-bpmn-moddle/resources/camunda.json', () => ({
+  default: { name: 'Camunda' },
+}))
+
+import { camunda7Engine } from '../../engines/camunda7'
+
+describe('camunda7Engine', () => {
+  it('registers the three Camunda Platform modules', () => {
+    expect(camunda7Engine.additionalModules).toHaveLength(3)
+  })
+
+  it('exposes the camunda moddle extension', () => {
+    expect(camunda7Engine.moddleExtensions).toHaveProperty('camunda')
+  })
+})

--- a/tests/engines/zeebe.test.ts
+++ b/tests/engines/zeebe.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('bpmn-js-properties-panel', () => ({
+  BpmnPropertiesPanelModule: { __id: 'panel' },
+  BpmnPropertiesProviderModule: { __id: 'provider' },
+  ZeebePropertiesProviderModule: { __id: 'zeebe-provider' },
+  CamundaPlatformPropertiesProviderModule: { __id: 'c7-provider' },
+}))
+vi.mock('camunda-bpmn-js-behaviors/lib/camunda-cloud', () => ({
+  default: { __id: 'zeebe-behaviors' },
+}))
+vi.mock('zeebe-bpmn-moddle/resources/zeebe.json', () => ({
+  default: { name: 'Zeebe' },
+}))
+
+import { zeebeEngine } from '../../engines/zeebe'
+
+describe('zeebeEngine', () => {
+  it('registers the four Zeebe modules', () => {
+    expect(zeebeEngine.additionalModules).toHaveLength(4)
+  })
+
+  it('exposes the zeebe moddle extension', () => {
+    expect(zeebeEngine.moddleExtensions).toHaveProperty('zeebe')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
       'bpmn-js/lib/Viewer',
       'bpmn-js/lib/Modeler',
       'bpmn-js-token-simulation/lib/viewer',
+      'bpmn-js-properties-panel',
+      'camunda-bpmn-js-behaviors/lib/camunda-cloud',
     ],
   },
 })


### PR DESCRIPTION
Closes #39

## Summary
- Adds optional `engine` prop (`"zeebe"` | `"camunda7"` | undefined) to `BpmnModeler` that mounts an engine-specific properties panel side-by-side with the canvas
- Engine wiring is split into one file per engine under `engines/` (SRP) — `engines/zeebe.ts`, `engines/camunda7.ts`, `engines/types.ts`
- Component picks the right config via a small `if` in `resolveEngineConfig()`; adding a new engine is one new file + one `if` line
- `example.md` now ships one Zeebe slide (existing `newsletter.bpmn`) and one Camunda 7 slide (new `public/loan-approval.bpmn` sample with `camunda:expression`); the blank-canvas slide stays engine-less to demonstrate backwards compatibility

## Dependencies (exact-pinned)
- `bpmn-js-properties-panel@5.54.0`
- `@bpmn-io/properties-panel@3.41.1`
- `zeebe-bpmn-moddle@1.13.0`
- `camunda-bpmn-moddle@7.0.1`
- `camunda-bpmn-js-behaviors@1.14.1`

## Test plan
- [x] `npm run test` — 48/48 pass (19 new tests across `tests/engines/{zeebe,camunda7}.test.ts` and engine-prop cases in `tests/components/BpmnModeler.test.ts`)
- [x] `npm run build` — production build succeeds
- [x] Dev-server smoke test (browser):
  - [x] Zeebe slide → Edit opens panel with Zeebe sections (`Execution listeners`, `Extension properties`)
  - [x] Camunda 7 slide → Edit opens panel with C7-only sections (`History cleanup`, `Tasklist`, `Candidate starter`, `External task`, `Process variables`, `Job execution`)
  - [x] Blank slide (no `engine` prop) → Edit opens canvas only, no panel — backwards-compatible
- [ ] Open / close / re-open behavior preserves edits made via the panel

## Known follow-ups (not in this PR)
- Toolbar layout: the fullscreen Close button currently sits over the panel; planned to be split into two buttons (Close + Toggle panel) inside the canvas pane