### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slidev-addon-bpmn",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slidev-addon-bpmn",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/properties-panel": "3.41.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slidev-addon-bpmn",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Display BPMN 2.0 diagrams in Slidev presentations",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release v1.5.0

Bumps version to `1.5.0` to release the following changes since v1.4.0:

- `feat: add engine prop to BpmnModeler for Zeebe and Camunda 7 properties panel (#40)`
- `chore: fix dark background and open browser on dev (#38)`
- `chore(deps-dev): bump vitest (#37)`