### PR TITLE
ci: enforce pinned npm dependencies in build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,9 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Verify pinned dependencies
-        uses: miragon/pin-npm-dependencies@v1
+      - uses: miragon/pin-npm-dependencies@v1
+        with:
+          files: package.json
 
       - run: npm ci
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "bpmn-js-token-simulation": "0.39.3",
         "camunda-bpmn-js-behaviors": "1.14.1",
         "camunda-bpmn-moddle": "7.0.1",
-        "camunda-transaction-boundaries": "^1.1.2",
+        "camunda-transaction-boundaries": "1.1.2",
         "zeebe-bpmn-moddle": "1.13.0"
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary

- Adds `files: package.json` input to the `miragon/pin-npm-dependencies@v1` action, matching the pattern used in [slidev-addon-dmn](https://github.com/emaarco/slidev-addon-dmn/commit/07091fa4d09612a31ac8424341965a1f6753050c)
- Fixes `package-lock.json` inconsistency where `camunda-transaction-boundaries` had `^1.1.2` despite being pinned as `1.1.2` in `package.json`

## Test plan

- [ ] Build CI passes with the pin check enforcing exact versions