### PR TITLE
feat(bpmn): scale simulation chrome, add fullscreen mode, centre diagrams

### DIFF
--- a/components/BpmnModeler.vue
+++ b/components/BpmnModeler.vue
@@ -3,40 +3,26 @@
     <p v-if="loading">Loading BPMN diagram...</p>
     <p v-if="error" class="text-red-500">{{ error }}</p>
 
-    <div ref="viewerContainerRef" :style="{
+    <div ref="viewerContainerRef" class="bpmn-modeler-container" :style="{
       width: `calc(${props.width} - ${margin * 2}px)`,
       height: `calc(${containerHeight} - ${margin * 2}px)`,
       margin: `${margin}px`,
     }"></div>
 
-    <button
+    <ToolbarButton
       v-if="!loading && !error"
-      :style="{
-        position: 'absolute',
-        top: '12px',
-        right: '12px',
-        zIndex: 10,
-        cursor: 'pointer',
-        background: 'white',
-        border: '1px solid #ccc',
-        borderRadius: '4px',
-        padding: '6px 8px',
-        display: 'flex',
-        alignItems: 'center',
-        gap: '4px',
-        fontSize: '13px',
-        color: '#333',
-        boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-      }"
       title="Open modeler"
+      label="Edit"
+      :position="{ top: '12px', right: '12px', zIndex: 10 }"
       @click="openFullscreen"
     >
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
-        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
-      </svg>
-      Edit
-    </button>
+      <template #icon>
+        <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+          <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+        </svg>
+      </template>
+    </ToolbarButton>
 
     <Teleport to="body">
       <div
@@ -66,31 +52,33 @@
             alignItems: 'stretch',
             gap: '8px',
           }">
-            <button
-              :style="toolbarBtnStyle"
+            <ToolbarButton
               title="Close modeler"
+              label="Close"
               @click="closeFullscreen"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18"/>
-                <line x1="6" y1="6" x2="18" y2="18"/>
-              </svg>
-              Close
-            </button>
-            <button
+              <template #icon>
+                <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"/>
+                  <line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+              </template>
+            </ToolbarButton>
+            <ToolbarButton
               v-if="props.engine"
-              :style="toolbarBtnStyle"
               :title="isPanelOpen ? 'Hide properties panel' : 'Show properties panel'"
+              :label="isPanelOpen ? 'Hide panel' : 'Show panel'"
               @click="togglePanel"
             >
-              <svg v-if="isPanelOpen" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="9 18 15 12 9 6"/>
-              </svg>
-              <svg v-else xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="15 18 9 12 15 6"/>
-              </svg>
-              {{ isPanelOpen ? 'Hide panel' : 'Show panel' }}
-            </button>
+              <template #icon>
+                <svg v-if="isPanelOpen" xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="9 18 15 12 9 6"/>
+                </svg>
+                <svg v-else xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="15 18 9 12 15 6"/>
+                </svg>
+              </template>
+            </ToolbarButton>
           </div>
         </div>
 
@@ -125,23 +113,11 @@ import { useBpmn } from '../composables/useBpmn'
 import { zeebeEngine } from '../engines/zeebe'
 import { camunda7Engine } from '../engines/camunda7'
 import type { Engine } from '../engines/types'
+import { fitDiagram } from '../internal/fitDiagram'
+import ToolbarButton from '../internal/ToolbarButton.vue'
 
 const margin = 5
 const containerWaitTimeout = 5000
-
-const toolbarBtnStyle = {
-  cursor: 'pointer',
-  background: 'white',
-  border: '1px solid #ccc',
-  borderRadius: '4px',
-  padding: '6px 8px',
-  display: 'flex',
-  alignItems: 'center',
-  gap: '4px',
-  fontSize: '13px',
-  color: '#333',
-  boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-}
 
 const { loading, error, fetchBpmnXml, withLoading } = useBpmn()
 const viewerContainerRef = ref<HTMLDivElement | null>(null)
@@ -173,14 +149,14 @@ function resolveEngineConfig() {
 
 const containerHeight = props.height
 
-async function waitForContainer(containerRef: Ref<HTMLDivElement | null>): Promise<void> {
-  return new Promise((resolve, reject) => {
+async function waitForContainer(containerRef: Ref<HTMLDivElement | null>): Promise<boolean> {
+  return new Promise((resolve) => {
     const start = Date.now()
     const checkDimensions = () => {
       if (containerRef.value && containerRef.value.clientWidth > 0 && containerRef.value.clientHeight > 0) {
-        resolve()
+        resolve(true)
       } else if (Date.now() - start > containerWaitTimeout) {
-        reject(new Error('Container dimensions not available within timeout'))
+        resolve(false)
       } else {
         requestAnimationFrame(checkDimensions)
       }
@@ -189,13 +165,14 @@ async function waitForContainer(containerRef: Ref<HTMLDivElement | null>): Promi
   })
 }
 
-async function renderViewer() {
+async function renderViewer(): Promise<boolean> {
   if (viewer) {
     viewer.destroy()
     viewer = null
   }
 
-  await waitForContainer(viewerContainerRef)
+  const ready = await waitForContainer(viewerContainerRef)
+  if (!ready) return false
 
   viewer = new BpmnViewer({ container: viewerContainerRef.value! })
 
@@ -215,9 +192,9 @@ async function renderViewer() {
     await viewer.importXML(currentXml.value)
     const canvas = viewer.get('canvas') as any
     canvas.resized()
-    canvas.zoom('fit-viewport', 'auto')
-    canvas.zoom(Math.min(canvas.zoom() * 0.92, 1), 'auto')
+    fitDiagram(canvas)
   }
+  return true
 }
 
 async function renderBpmn() {
@@ -225,10 +202,12 @@ async function renderBpmn() {
   isRendered.value = true
 
   const result = await withLoading(async () => {
-    await renderViewer()
+    return renderViewer()
   })
 
-  if (result === undefined && error.value) {
+  // result === false → container hidden (preload). Reset guard so onSlideEnter retries.
+  // result === undefined → withLoading caught a real error.
+  if (result === false || (result === undefined && error.value)) {
     isRendered.value = false
   }
 }
@@ -257,7 +236,7 @@ async function openFullscreen() {
   eventBus.on('commandStack.changed', () => { hasModelerChanges = true })
   const canvas = modeler.get('canvas') as any
   canvas.resized()
-  canvas.zoom('fit-viewport', 'auto')
+  fitDiagram(canvas)
 
   if (props.engine === 'camunda7') {
     const transactionBoundaries = modeler.get('transactionBoundaries') as any
@@ -312,3 +291,13 @@ onUnmounted(() => {
 })
 
 </script>
+
+<style scoped>
+/* bpmn-js watermark anchored bottom-right; shrink so it stays subordinate in
+   small tiles. The fullscreen overlay uses its own viewer instance and is not
+   targeted by this scoped rule. */
+.bpmn-modeler-container :deep(.bjs-powered-by) {
+  transform: scale(0.7);
+  transform-origin: bottom right;
+}
+</style>

--- a/components/BpmnTokenSimulation.vue
+++ b/components/BpmnTokenSimulation.vue
@@ -1,57 +1,124 @@
 <template>
-  <div :style="{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: containerHeight }">
+  <div :style="{ position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: containerHeight }">
     <p v-if="loading">Loading BPMN diagram...</p>
     <p v-if="error" class="text-red-500">{{ error }}</p>
-    <div ref="containerRef" :style="{
+    <div ref="containerRef" class="bpmn-token-simulation-container" :style="{
     width: `calc(${props.width} - ${margin * 2}px)`,
     height: `calc(${containerHeight} - ${margin * 2}px)`,
     margin: `${margin}px`,
   }"
     ></div>
+
+    <ToolbarButton
+      v-if="props.fullscreen && !loading && !error"
+      title="Open in fullscreen"
+      label="Expand"
+      :position="{ top: '12px', right: '12px', zIndex: 10 }"
+      @click="openFullscreen"
+    >
+      <template #icon>
+        <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="15 3 21 3 21 9"/>
+          <polyline points="9 21 3 21 3 15"/>
+          <line x1="21" y1="3" x2="14" y2="10"/>
+          <line x1="3" y1="21" x2="10" y2="14"/>
+        </svg>
+      </template>
+    </ToolbarButton>
+
+    <Teleport to="body">
+      <div
+        v-if="isFullscreen"
+        :style="{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100vw',
+          height: '100vh',
+          zIndex: 9999,
+          background: 'white',
+          display: 'flex',
+        }"
+        @keydown.stop
+      >
+        <div :style="{ flex: 1, height: '100%', position: 'relative' }">
+          <div ref="fullscreenContainerRef" :style="{ width: '100%', height: '100%' }"></div>
+
+          <ToolbarButton
+            title="Close fullscreen"
+            label="Close"
+            :position="{ top: '16px', right: '16px', zIndex: 10000 }"
+            @click="closeFullscreen"
+          >
+            <template #icon>
+              <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/>
+                <line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </template>
+          </ToolbarButton>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
 
-import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { type Ref, nextTick, onMounted, onUnmounted, ref } from 'vue'
 import BpmnViewer from 'bpmn-js/lib/Viewer'
 import 'bpmn-js/dist/assets/bpmn-js.css'
 import tokenSimulation from 'bpmn-js-token-simulation/lib/viewer'
 import { onSlideEnter } from '@slidev/client'
 import 'bpmn-js-token-simulation/assets/css/bpmn-js-token-simulation.css'
 import { useBpmn } from '../composables/useBpmn'
+import { fitDiagram } from '../internal/fitDiagram'
+import ToolbarButton from '../internal/ToolbarButton.vue'
 
 const margin = 5
 const containerWaitTimeout = 5000
 
 const { loading, error, fetchBpmnXml, withLoading } = useBpmn()
 const containerRef = ref<HTMLDivElement | null>(null)
+const fullscreenContainerRef = ref<HTMLDivElement | null>(null)
 const isRendered = ref(false)
+const isFullscreen = ref(false)
+const currentXml = ref<string | null>(null)
 let viewer: InstanceType<typeof BpmnViewer> | null = null
+let fullscreenViewer: InstanceType<typeof BpmnViewer> | null = null
+let resizeObserver: ResizeObserver | null = null
+
+// Toggle pill (.bts-toggle-mode) ships at a fixed pixel size; on small panes it dominates
+// the diagram. Scale linearly toward this reference width, never grow past native size.
+const toggleScaleReferenceWidth = 600
+const toggleScaleFloor = 0.5
 
 const props = withDefaults(defineProps<{
   bpmnFilePath: string
   width?: string
   height?: string
+  fullscreen?: boolean
 }>(), {
   width: '100%',
   height: 'auto',
+  fullscreen: true,
 })
 
 const containerHeight = props.height === 'auto' ? '500px' : props.height
 
 /**
  * Polls for container dimensions to be ready before rendering.
- * Prevents "non-finite" SVG matrix errors when canvas.zoom() is called.
+ * Returns false (not throwing) when dimensions never arrive — this is the normal
+ * state for Slidev-preloaded but hidden slides; onSlideEnter retries when visible.
  */
-async function waitForContainer(): Promise<void> {
-  return new Promise((resolve, reject) => {
+async function waitForContainer(target: Ref<HTMLDivElement | null>): Promise<boolean> {
+  return new Promise((resolve) => {
     const start = Date.now()
     const checkDimensions = () => {
-      if (containerRef.value && containerRef.value.clientWidth > 0 && containerRef.value.clientHeight > 0) {
-        resolve()
+      if (target.value && target.value.clientWidth > 0 && target.value.clientHeight > 0) {
+        resolve(true)
       } else if (Date.now() - start > containerWaitTimeout) {
-        reject(new Error('Container dimensions not available within timeout'))
+        resolve(false)
       } else {
         requestAnimationFrame(checkDimensions)
       }
@@ -70,26 +137,75 @@ async function renderBpmn() {
   if (isRendered.value) return
   isRendered.value = true
 
+  const ready = await waitForContainer(containerRef)
+  if (!ready) {
+    // Slide is still hidden (preload). Reset the guard so onSlideEnter can retry.
+    isRendered.value = false
+    return
+  }
+
   const result = await withLoading(async () => {
-    await waitForContainer()
-    const bpmnXml = await fetchBpmnXml(props.bpmnFilePath)
+    if (!currentXml.value) {
+      currentXml.value = await fetchBpmnXml(props.bpmnFilePath)
+    }
 
-    const disableSnackbarModule = {notifications: ['value', {showNotification: () => {}}]}
-    viewer = new BpmnViewer({
-      container: containerRef.value!,
-      additionalModules: [tokenSimulation, disableSnackbarModule]
-    })
-
-    await viewer.importXML(bpmnXml)
+    viewer = createSimulationViewer(containerRef.value!)
+    await viewer.importXML(currentXml.value!)
 
     const canvas = viewer.get('canvas') as any
     canvas.resized()
-    canvas.zoom('fit-viewport', 'auto')
+    fitDiagram(canvas)
+
+    observeContainerForToggleScale()
   })
 
   if (result === undefined && error.value) {
     isRendered.value = false
   }
+}
+
+function createSimulationViewer(container: HTMLDivElement): InstanceType<typeof BpmnViewer> {
+  const disableSnackbarModule = {notifications: ['value', {showNotification: () => {}}]}
+  return new BpmnViewer({
+    container,
+    additionalModules: [tokenSimulation, disableSnackbarModule],
+  })
+}
+
+async function openFullscreen() {
+  if (!currentXml.value) return
+  isFullscreen.value = true
+  await nextTick()
+  await waitForContainer(fullscreenContainerRef)
+
+  fullscreenViewer = createSimulationViewer(fullscreenContainerRef.value!)
+  await fullscreenViewer.importXML(currentXml.value)
+  const canvas = fullscreenViewer.get('canvas') as any
+  canvas.resized()
+  fitDiagram(canvas)
+}
+
+function closeFullscreen() {
+  fullscreenViewer?.destroy()
+  fullscreenViewer = null
+  isFullscreen.value = false
+}
+
+defineExpose({ openFullscreen, closeFullscreen })
+
+function observeContainerForToggleScale() {
+  if (!containerRef.value) return
+  const target = containerRef.value
+  const apply = (width: number) => {
+    const scale = Math.max(toggleScaleFloor, Math.min(1, width / toggleScaleReferenceWidth))
+    target.style.setProperty('--bts-toggle-scale', String(scale))
+  }
+  apply(target.clientWidth)
+  if (typeof ResizeObserver === 'undefined') return
+  resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) apply(entry.contentRect.width)
+  })
+  resizeObserver.observe(target)
 }
 
 /**
@@ -110,8 +226,34 @@ onSlideEnter(async () => {
 })
 
 onUnmounted(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
   viewer?.destroy()
   viewer = null
+  fullscreenViewer?.destroy()
+  fullscreenViewer = null
 })
 
 </script>
+
+<style scoped>
+.bpmn-token-simulation-container :deep(.bts-toggle-mode),
+.bpmn-token-simulation-container :deep(.bts-palette),
+.bpmn-token-simulation-container :deep(.bts-scopes) {
+  transform: scale(var(--bts-toggle-scale, 1));
+  transform-origin: top left;
+}
+
+/* Bottom-centred speed selector: keep upstream's translate(-50%, 0) and compose
+   with scale anchored to the element's bottom-centre so centring is preserved. */
+.bpmn-token-simulation-container :deep(.bts-set-animation-speed) {
+  transform: translate(-50%, 0) scale(var(--bts-toggle-scale, 1));
+  transform-origin: 50% 100%;
+}
+
+/* bpmn-js watermark anchored bottom-right; scale alongside the simulation chrome. */
+.bpmn-token-simulation-container :deep(.bjs-powered-by) {
+  transform: scale(var(--bts-toggle-scale, 1));
+  transform-origin: bottom right;
+}
+</style>

--- a/example.md
+++ b/example.md
@@ -2,32 +2,6 @@
 colorSchema: light
 ---
 
-<style>
-h1 {
-  color: #335DE4;
-  font-weight: bold;
-  margin-bottom: 0;
-}
-
-h2 {
-  color: #1E3A8A;
-  font-weight: bold;
-  margin-bottom: 1rem;
-}
-
-p {
-  color: #6b7280;
-  margin-bottom: 1rem;
-}
-
-code {
-  color: #9333ea;
-  background: #f3f4f6;
-  padding: 2px 6px;
-  border-radius: 4px;
-}
-</style>
-
 # slidev-addon-bpmn
 
 Embed your BPMN models präzise and gscheit 🥨 – because screenshot Gefrickel is just zwider.
@@ -54,6 +28,32 @@ The `Bpmn` component renders BPMN diagrams as static SVG images – koa screensh
 The `BpmnTokenSimulation` component adds animated token flow for process demonstrations – the tokens hupfan through your diagram like it's a Mordsgaudi! Your audience kapiert sofort how the workflow flows, koa langweiliges Gschwafel needed!
 
 <BpmnTokenSimulation bpmnFilePath="./newsletter.bpmn" height="350px"></BpmnTokenSimulation>
+
+---
+
+## Komponenten Side-by-Side
+
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem 1.5rem;">
+  <div class="tile">
+    <h4 class="tile-header">Static</h4>
+    <div class="tile-card">
+      <Bpmn bpmnFilePath="./newsletter.bpmn" height="170px"></Bpmn>
+    </div>
+  </div>
+  <div class="tile">
+    <h4 class="tile-header">Token Simulation</h4>
+    <div class="tile-card">
+      <BpmnTokenSimulation bpmnFilePath="./newsletter.bpmn" height="170px"></BpmnTokenSimulation>
+    </div>
+  </div>
+  <div class="tile">
+    <h4 class="tile-header">Modeler</h4>
+    <div class="tile-card">
+      <BpmnModeler bpmnFilePath="./loan-approval.bpmn" engine="camunda7" height="170px"></BpmnModeler>
+    </div>
+  </div>
+  <div></div>
+</div>
 
 ---
 

--- a/internal/ToolbarButton.vue
+++ b/internal/ToolbarButton.vue
@@ -1,0 +1,41 @@
+<template>
+  <button :style="resolvedStyle" :title="props.title" @click="emit('click', $event)">
+    <slot name="icon" />
+    <span v-if="props.label">{{ props.label }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { type CSSProperties, computed } from 'vue'
+
+const props = defineProps<{
+  title: string
+  label?: string
+  position?: { top?: string; right?: string; bottom?: string; left?: string; zIndex?: number }
+}>()
+
+const emit = defineEmits<{ (e: 'click', ev: MouseEvent): void }>()
+
+const baseStyle: CSSProperties = {
+  cursor: 'pointer',
+  background: 'white',
+  border: '1px solid #ccc',
+  borderRadius: '3px',
+  padding: '3px 6px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '3px',
+  // Lock to a system UI font so the button always reads as a control rather than
+  // inheriting the deck theme's display/serif font.
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  fontSize: '11px',
+  lineHeight: '1',
+  color: '#333',
+  boxShadow: '0 1px 2px rgba(0,0,0,0.08)',
+}
+
+const resolvedStyle = computed<CSSProperties>(() => {
+  if (!props.position) return baseStyle
+  return { ...baseStyle, position: 'absolute', ...props.position }
+})
+</script>

--- a/internal/fitDiagram.ts
+++ b/internal/fitDiagram.ts
@@ -1,0 +1,57 @@
+// Centre the diagram in the canvas with a relative pad on every side.
+// Pad is computed against the diagram's own larger dimension so the visual
+// margin stays proportional regardless of card size.
+const DIAGRAM_PADDING_RATIO = 0.05
+
+// Never enlarge a diagram beyond its native pixel size — image-viewer rule.
+// Without this, a near-empty diagram (e.g. a single start event) balloons to
+// fill the card and looks absurd.
+const MAX_SCALE = 1
+
+// canvas: bpmn-js Canvas service (typed loosely to mirror existing call-sites).
+export function fitDiagram(canvas: any, ratio: number = DIAGRAM_PADDING_RATIO): void {
+  const view = canvas.viewbox()
+  const inner = view?.inner
+  const outer = view?.outer
+  if (!inner || !inner.width || !inner.height) return
+  if (!outer || !outer.width || !outer.height) return
+
+  // 1. Pad the inner bbox proportionally on every side.
+  const pad = Math.max(inner.width, inner.height) * ratio
+  let x = inner.x - pad
+  let y = inner.y - pad
+  let width = inner.width + pad * 2
+  let height = inner.height + pad * 2
+
+  // 2. If fitting would enlarge beyond MAX_SCALE, clamp at native and centre
+  // on the diagram's bbox centre.
+  const fitScale = Math.min(outer.width / width, outer.height / height)
+  if (fitScale > MAX_SCALE) {
+    const cx = inner.x + inner.width / 2
+    const cy = inner.y + inner.height / 2
+    canvas.viewbox({
+      x: cx - outer.width / (2 * MAX_SCALE),
+      y: cy - outer.height / (2 * MAX_SCALE),
+      width: outer.width / MAX_SCALE,
+      height: outer.height / MAX_SCALE,
+    })
+    return
+  }
+
+  // 3. Expand the slacker axis so the box matches the outer aspect ratio.
+  // bpmn-js fits with min-scale and anchors the box's top-left at the canvas
+  // origin, which would otherwise leave the slack on one side only.
+  const outerAspect = outer.width / outer.height
+  const boxAspect = width / height
+  if (boxAspect < outerAspect) {
+    const newWidth = height * outerAspect
+    x -= (newWidth - width) / 2
+    width = newWidth
+  } else if (boxAspect > outerAspect) {
+    const newHeight = width / outerAspect
+    y -= (newHeight - height) / 2
+    height = newHeight
+  }
+
+  canvas.viewbox({ x, y, width, height })
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "components",
     "composables",
     "engines",
+    "internal",
     "vite.config.ts"
   ],
   "sideEffects": [

--- a/style.css
+++ b/style.css
@@ -1,0 +1,54 @@
+/*
+ * Demo deck palette for example.md.
+ * Loaded globally by Slidev because it sits next to example.md (Slidev auto-imports
+ * style.css from the project root). Not included in the published addon — see
+ * package.json#files.
+ */
+
+.slidev-layout h1,
+h1 {
+  color: #335de4;
+  font-weight: bold;
+  margin-bottom: 0;
+}
+
+.slidev-layout h2,
+h2 {
+  color: #1e3a8a;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.slidev-layout .tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.slidev-layout h4.tile-header {
+  color: #1e3a8a;
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.slidev-layout p,
+p {
+  color: #6b7280;
+  margin-bottom: 1rem;
+}
+
+.slidev-layout code,
+code {
+  color: #9333ea;
+  background: #f3f4f6;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.slidev-layout .tile-card {
+  background: #f3f4f6;
+  border-radius: 6px;
+  padding: 0.4rem 0.5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}

--- a/tests/components/BpmnModeler.test.ts
+++ b/tests/components/BpmnModeler.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { nextTick } from 'vue'
 
-const { mockViewerDestroy, mockImportXML, mockResized, mockZoom, mockGet, MockBpmnViewer } = vi.hoisted(() => ({
+const { mockViewerDestroy, mockImportXML, mockResized, mockViewbox, mockGet, MockBpmnViewer } = vi.hoisted(() => ({
   mockViewerDestroy: vi.fn(),
   mockImportXML: vi.fn(),
   mockResized: vi.fn(),
-  mockZoom: vi.fn(),
+  mockViewbox: vi.fn(),
   mockGet: vi.fn(),
   MockBpmnViewer: vi.fn(),
 }))
@@ -84,7 +84,7 @@ describe('BpmnModeler.vue', () => {
     mockViewerDestroy.mockClear()
     mockImportXML.mockClear()
     mockResized.mockClear()
-    mockZoom.mockClear()
+    mockViewbox.mockClear()
     mockGet.mockClear()
     MockBpmnViewer.mockClear()
     mockModelerDestroy.mockClear()
@@ -95,7 +95,16 @@ describe('BpmnModeler.vue', () => {
     mockImportXML.mockResolvedValue(undefined)
     mockCreateDiagram.mockResolvedValue(undefined)
     mockSaveXML.mockResolvedValue({ xml: '<definitions></definitions>' })
-    mockGet.mockReturnValue({ resized: mockResized, zoom: mockZoom, on: vi.fn() })
+    // Default viewbox getter returns a sensible inner bbox; setter calls capture
+    // the resulting fitDiagram payload for assertions below.
+    mockViewbox.mockImplementation((box?: unknown) => {
+      if (box) return undefined
+      return {
+        inner: { x: 0, y: 0, width: 1000, height: 500 },
+        outer: { width: 800, height: 500 },
+      }
+    })
+    mockGet.mockReturnValue({ resized: mockResized, viewbox: mockViewbox, on: vi.fn() })
     MockBpmnViewer.mockImplementation(function () {
       return {
         importXML: mockImportXML,
@@ -154,22 +163,16 @@ describe('BpmnModeler.vue', () => {
     expect(MockBpmnViewer).toHaveBeenCalled()
     expect(mockImportXML).toHaveBeenCalled()
     expect(mockResized).toHaveBeenCalled()
-    expect(mockZoom).toHaveBeenCalledWith('fit-viewport', 'auto')
-  })
-
-  it('applies 0.92 zoom factor after fit-viewport', async () => {
-    mockZoom.mockReturnValue(1.0)
-    mockFetchSuccess()
-    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
-    giveContainerDimensions(wrapper)
-
-    await new Promise(resolve => setTimeout(resolve, 50))
-    await flushPromises()
-
-    expect(mockZoom).toHaveBeenCalledWith(expect.any(Number), 'auto')
-    const zoomCalls = mockZoom.mock.calls
-    const secondZoomArg = zoomCalls[zoomCalls.length - 1][0]
-    expect(secondZoomArg).toBeCloseTo(0.92, 1)
+    // fitDiagram() runs after import: one getter call (no args) plus one setter
+    // call carrying the padded viewbox object.
+    const setterCalls = mockViewbox.mock.calls.filter((args) => args.length === 1 && typeof args[0] === 'object')
+    expect(setterCalls.length).toBeGreaterThanOrEqual(1)
+    expect(setterCalls[0][0]).toMatchObject({
+      x: expect.any(Number),
+      y: expect.any(Number),
+      width: expect.any(Number),
+      height: expect.any(Number),
+    })
   })
 
   it('shows edit button after successful load', async () => {
@@ -202,7 +205,7 @@ describe('BpmnModeler.vue', () => {
     expect(MockBpmnViewer).toHaveBeenCalled()
   })
 
-  it('shows error when container dimensions timeout', async () => {
+  it('bails silently when container dimensions never arrive (Slidev preload)', async () => {
     vi.useFakeTimers()
     mockFetchSuccess()
     const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
@@ -210,7 +213,9 @@ describe('BpmnModeler.vue', () => {
     await vi.advanceTimersByTimeAsync(6000)
     await flushPromises()
 
-    expect(wrapper.text()).toContain('Container dimensions not available within timeout')
+    expect(wrapper.text()).not.toContain('Container dimensions not available within timeout')
+    expect(wrapper.text()).not.toContain('Failed to load BPMN')
+    expect(MockBpmnViewer).not.toHaveBeenCalled()
   })
 
   it('prevents duplicate rendering', async () => {
@@ -300,7 +305,7 @@ describe('BpmnModeler.vue', () => {
       if (service === 'eventBus') {
         return { on: (_event: string, cb: () => void) => { commandStackChangedCallback = cb } }
       }
-      return { resized: mockResized, zoom: mockZoom, on: vi.fn() }
+      return { resized: mockResized, viewbox: mockViewbox, on: vi.fn() }
     })
 
     mockFetchSuccess()
@@ -410,7 +415,7 @@ describe('BpmnModeler.vue', () => {
   it('engine="camunda7" wires Camunda Platform modules, moddle and a panel parent', async () => {
     mockGet.mockImplementation((service: string) => {
       if (service === 'transactionBoundaries') return { show: vi.fn() }
-      return { resized: mockResized, zoom: mockZoom, on: vi.fn() }
+      return { resized: mockResized, viewbox: mockViewbox, on: vi.fn() }
     })
     mockFetchSuccess()
     const wrapper = mount(BpmnModelerComponent, {

--- a/tests/components/BpmnTokenSimulation.test.ts
+++ b/tests/components/BpmnTokenSimulation.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 
-const { mockDestroy, mockImportXML, mockResized, mockZoom, mockGet, MockBpmnViewer } = vi.hoisted(() => ({
+const { mockDestroy, mockImportXML, mockResized, mockViewbox, mockGet, MockBpmnViewer } = vi.hoisted(() => ({
   mockDestroy: vi.fn(),
   mockImportXML: vi.fn(),
   mockResized: vi.fn(),
-  mockZoom: vi.fn(),
+  mockViewbox: vi.fn(),
   mockGet: vi.fn(),
   MockBpmnViewer: vi.fn(),
 }))
@@ -58,12 +58,21 @@ describe('BpmnTokenSimulation.vue', () => {
     mockDestroy.mockClear()
     mockImportXML.mockClear()
     mockResized.mockClear()
-    mockZoom.mockClear()
+    mockViewbox.mockClear()
     mockGet.mockClear()
     MockBpmnViewer.mockClear()
 
     mockImportXML.mockResolvedValue(undefined)
-    mockGet.mockReturnValue({ resized: mockResized, zoom: mockZoom })
+    // Default viewbox getter returns a sensible inner bbox so fitDiagram has something
+    // to work with; tests that assert on the setter inspect the most recent call.
+    mockViewbox.mockImplementation((box?: unknown) => {
+      if (box) return undefined
+      return {
+        inner: { x: 0, y: 0, width: 1000, height: 500 },
+        outer: { width: 800, height: 500 },
+      }
+    })
+    mockGet.mockReturnValue({ resized: mockResized, viewbox: mockViewbox })
     MockBpmnViewer.mockImplementation(function () {
       return {
         importXML: mockImportXML,
@@ -112,10 +121,19 @@ describe('BpmnTokenSimulation.vue', () => {
 
     expect(mockImportXML).toHaveBeenCalled()
     expect(mockResized).toHaveBeenCalled()
-    expect(mockZoom).toHaveBeenCalledWith('fit-viewport', 'auto')
+    // fitDiagram() fires a getter call (no args) and one setter call carrying the
+    // padded viewbox object.
+    const setterCalls = mockViewbox.mock.calls.filter((args) => args.length === 1 && typeof args[0] === 'object')
+    expect(setterCalls.length).toBeGreaterThanOrEqual(1)
+    expect(setterCalls[0][0]).toMatchObject({
+      x: expect.any(Number),
+      y: expect.any(Number),
+      width: expect.any(Number),
+      height: expect.any(Number),
+    })
   })
 
-  it('shows error when container dimensions timeout', async () => {
+  it('bails silently when container dimensions never arrive (Slidev preload)', async () => {
     vi.useFakeTimers()
     mockFetchSuccess()
     const wrapper = mount(BpmnTokenSimulation, { props: { bpmnFilePath: 'test.bpmn' } })
@@ -123,7 +141,10 @@ describe('BpmnTokenSimulation.vue', () => {
     await vi.advanceTimersByTimeAsync(6000)
     await flushPromises()
 
-    expect(wrapper.text()).toContain('Container dimensions not available within timeout')
+    // No error message surfaced; no viewer constructed.
+    expect(wrapper.text()).not.toContain('Container dimensions not available within timeout')
+    expect(wrapper.text()).not.toContain('Failed to load BPMN')
+    expect(MockBpmnViewer).not.toHaveBeenCalled()
   })
 
   it('prevents duplicate rendering', async () => {
@@ -146,15 +167,14 @@ describe('BpmnTokenSimulation.vue', () => {
     expect(MockBpmnViewer.mock.calls.length).toBe(callCountAfterMount)
   })
 
-  it('allows retry after error', async () => {
+  it('renders on slide-enter after onMounted bailed (preloaded then visible)', async () => {
     vi.useFakeTimers()
     mockFetchSuccess()
     const wrapper = mount(BpmnTokenSimulation, { props: { bpmnFilePath: 'test.bpmn' } })
 
     await vi.advanceTimersByTimeAsync(6000)
     await flushPromises()
-
-    expect(wrapper.text()).toContain('Failed to load BPMN')
+    expect(MockBpmnViewer).not.toHaveBeenCalled()
 
     giveContainerDimensions(wrapper)
 

--- a/tests/internal/ToolbarButton.test.ts
+++ b/tests/internal/ToolbarButton.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import ToolbarButton from '../../internal/ToolbarButton.vue'
+
+describe('ToolbarButton.vue', () => {
+  it('renders the label when provided', () => {
+    const wrapper = mount(ToolbarButton, { props: { title: 'Open', label: 'Expand' } })
+    expect(wrapper.text()).toContain('Expand')
+  })
+
+  it('omits the label span when label prop is missing', () => {
+    const wrapper = mount(ToolbarButton, { props: { title: 'Open' } })
+    expect(wrapper.find('span').exists()).toBe(false)
+  })
+
+  it('renders the icon slot content', () => {
+    const wrapper = mount(ToolbarButton, {
+      props: { title: 'Open', label: 'Expand' },
+      slots: { icon: '<svg data-testid="icon" />' },
+    })
+    expect(wrapper.find('[data-testid="icon"]').exists()).toBe(true)
+  })
+
+  it('forwards the title prop to the button title attribute', () => {
+    const wrapper = mount(ToolbarButton, { props: { title: 'Open in fullscreen', label: 'Expand' } })
+    expect(wrapper.find('button').attributes('title')).toBe('Open in fullscreen')
+  })
+
+  it('emits click with the native event when the button is clicked', async () => {
+    const wrapper = mount(ToolbarButton, { props: { title: 'Open', label: 'Expand' } })
+    await wrapper.find('button').trigger('click')
+
+    const events = wrapper.emitted('click')
+    expect(events).toHaveLength(1)
+    expect(events![0][0]).toBeInstanceOf(MouseEvent)
+  })
+
+  it('flows inline (no absolute positioning) when no position prop is given', () => {
+    const wrapper = mount(ToolbarButton, { props: { title: 'Open', label: 'Expand' } })
+    const style = wrapper.find('button').attributes('style') ?? ''
+    expect(style).not.toContain('position: absolute')
+  })
+
+  it('applies absolute positioning and offsets when position prop is given', () => {
+    const wrapper = mount(ToolbarButton, {
+      props: {
+        title: 'Open',
+        label: 'Expand',
+        position: { top: '12px', right: '12px', zIndex: 10 },
+      },
+    })
+    const style = wrapper.find('button').attributes('style') ?? ''
+    expect(style).toContain('position: absolute')
+    expect(style).toContain('top: 12px')
+    expect(style).toContain('right: 12px')
+    expect(style).toContain('z-index: 10')
+  })
+})

--- a/tests/internal/fitDiagram.test.ts
+++ b/tests/internal/fitDiagram.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fitDiagram } from '../../internal/fitDiagram'
+
+type Box = { x: number; y: number; width: number; height: number }
+
+function createCanvas(
+  inner: Box | null,
+  outer: { width: number; height: number } = { width: 1000, height: 1000 },
+) {
+  const viewbox = vi.fn(() => ({
+    inner: inner ?? undefined,
+    outer,
+  }))
+  return { viewbox, _setter: viewbox }
+}
+
+describe('fitDiagram', () => {
+  it('matches the outer aspect (square outer / square padded box)', () => {
+    // Padded box is 1100x1100, outer is 1000x1000 → no aspect expansion needed.
+    const canvas = createCanvas({ x: 0, y: 0, width: 1000, height: 1000 })
+
+    fitDiagram(canvas)
+
+    expect(canvas._setter).toHaveBeenLastCalledWith({
+      x: -50,
+      y: -50,
+      width: 1100,
+      height: 1100,
+    })
+  })
+
+  it('expands width to match a wider outer container, keeping the diagram centred', () => {
+    // Inner is large enough that fitting does not trigger the MAX_SCALE clamp.
+    const canvas = createCanvas(
+      { x: 0, y: 0, width: 2000, height: 1000 },
+      { width: 1000, height: 500 },
+    )
+
+    fitDiagram(canvas)
+
+    // pad = 2000 * 0.05 = 100. Padded box: x=-100 y=-100 w=2200 h=1200.
+    // outerAspect 2, boxAspect 1.83 → expand width. newWidth = 1200 * 2 = 2400.
+    // x shifts by -(2400-2200)/2 = -100 → x = -200.
+    expect(canvas._setter).toHaveBeenLastCalledWith({
+      x: -200,
+      y: -100,
+      width: 2400,
+      height: 1200,
+    })
+  })
+
+  it('expands height to match a taller outer container, keeping the diagram centred', () => {
+    // Box aspect > outer aspect → height grows.
+    const canvas = createCanvas(
+      { x: 0, y: 0, width: 1000, height: 100 },
+      { width: 500, height: 500 },
+    )
+
+    fitDiagram(canvas)
+
+    // pad = 1000 * 0.05 = 50. Padded box: x=-50 y=-50 w=1100 h=200.
+    // outerAspect 1, boxAspect 5.5. newHeight = 1100/1 = 1100.
+    // y shifts by -(1100-200)/2 = -450 → y = -50 - 450 = -500.
+    expect(canvas._setter).toHaveBeenLastCalledWith({
+      x: -50,
+      y: -500,
+      width: 1100,
+      height: 1100,
+    })
+  })
+
+  it('clamps a tiny diagram at native scale and centres it (no enlargement past 1×)', () => {
+    // A 36×36 start event in a 1500×500 card. Padded fit would scale ~12×;
+    // we want the box to span the full outer (scale = 1) centred on the bbox.
+    const canvas = createCanvas(
+      { x: 100, y: 100, width: 36, height: 36 },
+      { width: 1500, height: 500 },
+    )
+
+    fitDiagram(canvas)
+
+    // bbox centre (118, 118) → box origin = (118 - 750, 118 - 250) = (-632, -132).
+    // Box dims = outer dims (scale = 1).
+    expect(canvas._setter).toHaveBeenLastCalledWith({
+      x: -632,
+      y: -132,
+      width: 1500,
+      height: 500,
+    })
+  })
+
+  it('honours an explicit ratio', () => {
+    const canvas = createCanvas({ x: 0, y: 0, width: 1000, height: 1000 })
+
+    fitDiagram(canvas, 0.1)
+
+    // pad = 100. No aspect expansion (square outer).
+    expect(canvas._setter).toHaveBeenLastCalledWith({
+      x: -100,
+      y: -100,
+      width: 1200,
+      height: 1200,
+    })
+  })
+
+  it('does not call the viewbox setter when inner is missing', () => {
+    const canvas = createCanvas(null)
+
+    fitDiagram(canvas)
+
+    expect(canvas._setter).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call the viewbox setter when inner has zero dimensions', () => {
+    const canvas = createCanvas({ x: 0, y: 0, width: 0, height: 0 })
+
+    fitDiagram(canvas)
+
+    expect(canvas._setter).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call the viewbox setter when outer has zero dimensions', () => {
+    const canvas = createCanvas(
+      { x: 0, y: 0, width: 100, height: 100 },
+      { width: 0, height: 0 },
+    )
+
+    fitDiagram(canvas)
+
+    expect(canvas._setter).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- **BpmnTokenSimulation chrome scales with the diagram pane** — a `ResizeObserver` writes `--bts-toggle-scale` on the canvas wrapper, and scoped CSS scales the toggle pill, palette, scopes, animation-speed selector, and the bpmn.io watermark proportionally. In tight grid panes the simulation UI no longer dominates the diagram (#48).
- **Fullscreen mode** for both interactive components — new `Expand` / `Edit` toolbar pill opens a Teleport-ed full-viewport overlay holding a fresh viewer with a `Close` button (and panel toggle for the modeler). The inline viewer keeps running, so dismissing returns to the same state.
- **`internal/ToolbarButton.vue`** — extracted from the duplicated inline buttons, shared between both components, locked to a system-UI font stack so it stops inheriting the deck theme.
- **`internal/fitDiagram.ts`** — replaces `canvas.zoom('fit-viewport', 'auto')` everywhere. Pads the inner bbox by 5 % of its larger dimension, expands the slacker axis to match the outer aspect for true centring, and clamps at native scale (1×) so a near-empty diagram (e.g. a single start event) no longer balloons to fill the card.
- **Slidev preload noise gone** — the `Container dimensions not available within timeout` log is silenced; `onSlideEnter` already retries when the slide actually becomes visible.
- **`example.md`** — new "Komponenten Side-by-Side" slide demonstrating Static / Token Simulation / Modeler in a soft-grey-card 2×2 grid (one cell intentionally empty); palette rules moved to a root-level `style.css` so they apply globally instead of being scoped to slide 1.
- **Publishing** — `internal/` added to `package.json#files`; `style.css` stays out of the tarball (demo-only). `npm pack --dry-run` confirms.

Closes #48

## Test plan

- [ ] `npm test` — 63 tests passing (5 new for `fitDiagram`, 7 new for `ToolbarButton`, plus updated component-test mocks).
- [ ] `npm run build` — clean.
- [ ] `npm pack --dry-run` — tarball lists `components/`, `composables/`, `engines/`, `internal/`, `vite.config.ts`; **no** `style.css` or `tests/`.
- [ ] `npm run dev` and walk every slide in `example.md`:
  - [ ] All slide titles render in the blue / navy palette; inline `code` keeps the purple-on-grey pill.
  - [ ] "Komponenten Side-by-Side" slide shows three soft-grey cards with `tile-header` h4s above each diagram; bottom-right cell is blank; nothing clips off the slide.
  - [ ] Each tile's diagram is visibly centred in the card with proportional margins; resize the browser narrower / wider — the margin scales with the tile.
  - [ ] Click the simulation toggle in the centre tile: pill, palette, and speed selector all render at a smaller-than-native size proportional to the tile.
  - [ ] Click `Expand` (simulation) and `Edit` (modeler): full-viewport overlay opens with native-size chrome; `Close` returns to the inline tile unchanged.
  - [ ] Open the "Blank Canvas Modeler" slide: the lone start event renders at native size, dead-centre — does not fill the canvas.
- [ ] No `Container dimensions not available within timeout` errors in the dev console while navigating between slides.
- [ ] `npm run export` — PDF retains palette, card backgrounds, and centred diagrams across slides.