### PR TITLE
docs: add historical changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+
+# [1.7.0](https://github.com/emaarco/slidev-addon-bpmn/compare/v1.5.0...v1.7.0) (2026-05-05)
+
+
+### Features
+
+* add camunda-transaction-boundaries plugin for Camunda 7 modeler ([#43](https://github.com/emaarco/slidev-addon-bpmn/issues/43)) ([7bfeb50](https://github.com/emaarco/slidev-addon-bpmn/commit/7bfeb50d0ca772b1644340ee9bc3d822654f2d7d)), closes [#42](https://github.com/emaarco/slidev-addon-bpmn/issues/42)
+* **bpmn:** scale simulation chrome, add fullscreen mode, centre diagrams ([#49](https://github.com/emaarco/slidev-addon-bpmn/issues/49)) ([f307325](https://github.com/emaarco/slidev-addon-bpmn/commit/f307325914e79b0f7ec1172122fcef8797eebe0b)), closes [#48](https://github.com/emaarco/slidev-addon-bpmn/issues/48) [package.json#files](https://github.com/package.json/issues/files)
+
+# [1.5.0](https://github.com/emaarco/slidev-addon-bpmn/compare/v1.3.0...v1.5.0) (2026-04-24)
+
+
+### Features
+
+* add engine prop to BpmnModeler for Zeebe and Camunda 7 properties panel ([#40](https://github.com/emaarco/slidev-addon-bpmn/issues/40)) ([f51911b](https://github.com/emaarco/slidev-addon-bpmn/commit/f51911b6fe45321fc8b22ff26ac0940546da3e73)), closes [#39](https://github.com/emaarco/slidev-addon-bpmn/issues/39)
+* add interactive BpmnModeler component ([#31](https://github.com/emaarco/slidev-addon-bpmn/issues/31)) ([6f27835](https://github.com/emaarco/slidev-addon-bpmn/commit/6f27835a7ed4a21233cd8843a9daa85da2d389d9)), closes [#12](https://github.com/emaarco/slidev-addon-bpmn/issues/12)
+
+# [1.3.0](https://github.com/emaarco/slidev-addon-bpmn/compare/v1.2.1...v1.3.0) (2026-04-03)
+
+
+### Bug Fixes
+
+* improve Bpmn viewer sizing and alignment ([#33](https://github.com/emaarco/slidev-addon-bpmn/issues/33)) ([1aa0e8c](https://github.com/emaarco/slidev-addon-bpmn/commit/1aa0e8c6ec9d48200abf38f7085dc24306a5a8e4))
+
+
+### Features
+
+* deploy live demo to GitHub Pages ([#27](https://github.com/emaarco/slidev-addon-bpmn/issues/27)) ([31b93b5](https://github.com/emaarco/slidev-addon-bpmn/commit/31b93b5a2af1899027dff55001e8b58e93099156))
+
+## [1.2.1](https://github.com/emaarco/slidev-addon-bpmn/compare/v1.2.0...v1.2.1) (2026-03-25)
+
+
+### Bug Fixes
+
+* perform review on repository level ([#16](https://github.com/emaarco/slidev-addon-bpmn/issues/16)) ([4211522](https://github.com/emaarco/slidev-addon-bpmn/commit/421152217684c4d35db939beb77e45488fbc8485))
+
+
+### Features
+
+* add create-ticket skill and GitHub issue templates ([#7](https://github.com/emaarco/slidev-addon-bpmn/issues/7)) ([36d91cf](https://github.com/emaarco/slidev-addon-bpmn/commit/36d91cfc546b441b2533324f84af1ccd2aa9b55a))
+* integrate Portless for stable .localhost dev URLs ([#14](https://github.com/emaarco/slidev-addon-bpmn/issues/14)) ([04715af](https://github.com/emaarco/slidev-addon-bpmn/commit/04715af17c4860e1851736b4a3228923b76d3a67))
+* replace static README image with animated GIF ([#17](https://github.com/emaarco/slidev-addon-bpmn/issues/17)) ([b694462](https://github.com/emaarco/slidev-addon-bpmn/commit/b6944626ac0556e8d36ac29c233049929723092f)), closes [#15](https://github.com/emaarco/slidev-addon-bpmn/issues/15)
+
+# [1.2.0](https://github.com/emaarco/slidev-addon-bpmn/compare/v1.0.0...v1.2.0) (2026-02-16)
+
+
+### Features
+
+* add token-simulation component ([#2](https://github.com/emaarco/slidev-addon-bpmn/issues/2)) ([abf1273](https://github.com/emaarco/slidev-addon-bpmn/commit/abf12730f335318c2ce2d29afebc02a44c8d3bf5))
+* render bpmnTokenSimulation component in pdf ([#4](https://github.com/emaarco/slidev-addon-bpmn/issues/4)) ([89405c4](https://github.com/emaarco/slidev-addon-bpmn/commit/89405c4bf22ac30f2c4c4b5df07c6e89019aac04))
+
+# [1.0.0](https://github.com/emaarco/slidev-addon-bpmn/compare/20f28c103d4f83c182979fabbe3e52e4339af50b...v1.0.0) (2026-02-10)
+
+
+### Features
+
+* initial commit - slidev bpmn addon ([20f28c1](https://github.com/emaarco/slidev-addon-bpmn/commit/20f28c103d4f83c182979fabbe3e52e4339af50b))


### PR DESCRIPTION
## Summary
- Backfill `CHANGELOG.md` with all releases from `v1.0.0` through `v1.7.0`, generated via `conventional-changelog-cli` (angular preset) so future release-please runs can append new entries on top.

## Notes
- Releases without `feat`/`fix` commits (`v1.0.1`, `v1.0.2`, `v1.1.0`, `v1.4.0`, `v1.6.0`) don't appear as standalone sections — this is the default conventional-changelog behavior. The compare ranges (e.g. `v1.5.0...v1.7.0`) skip over them accordingly.

## Test plan
- [ ] Verify the next release-please PR prepends its section above the existing `# [1.7.0]` heading without reformatting prior entries.