### PR TITLE
ci: authenticate release-please via GitHub App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,9 +22,15 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - id: rp
         uses: googleapis/release-please-action@v5
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           dry-run: ${{ inputs.dry_run == true }}


### PR DESCRIPTION
## Summary

Migrates the `release-please` job to authenticate via a **GitHub App** token instead of the built-in `GITHUB_TOKEN`, as requested in #62 and mirroring the proven setup in `miragon/wardley-maps-modeler`.

- Adds an `actions/create-github-app-token@v2` step that mints a short-lived installation token from the App (`vars.RELEASE_PLEASE_APP_ID` + `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY`).
- Passes `token: ${{ steps.app-token.outputs.token }}` to `googleapis/release-please-action@v5`.
- No `permissions:` change needed; `publish` / `deploy-pages` / `publish-dry-run` jobs are untouched.

## Why

- `GITHUB_TOKEN`-created events are suppressed by GitHub's loop prevention, so the release-please PR and its release commit/tag **don't trigger downstream CI**. An App token fixes this.
- Commits, tags and releases get attributed to a **named release bot** instead of `github-actions[bot]`.

## Required repo configuration

Already provisioned — the App is installed and these are set:

- Variable `RELEASE_PLEASE_APP_ID`
- Secret `RELEASE_PLEASE_APP_PRIVATE_KEY`

## Verification

- [x] Workflow YAML parses.
- [ ] After merge: confirm the next release-please PR is opened by the App bot (not `github-actions[bot]`) and that downstream workflows trigger on it.
- [ ] Confirm `npm publish` / GitHub Pages jobs still run on an actual release.

Refs #62