### PR TITLE
chore(ci): pin github actions to exact version tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.3
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '24'
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
@@ -44,10 +44,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.3
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -69,20 +69,20 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.3
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '24'
       - run: npm ci
       - run: npm run build:pages
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/configure-pages@v6.0.0
+      - uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: dist
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v5.0.0
 
   publish-dry-run:
     needs: release-please
@@ -92,8 +92,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v6.0.3
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## What

Replaces all **moving** version references on external GitHub Actions with **exact version tags** (`@vX.Y.Z`). Locally-referenced reusable workflows and actions already pinned to a full commit SHA are left untouched.

## Why

Major-only refs like `@v6` silently track every new minor/major release of an action. A surprise update can break CI or, worse, introduce malicious code if an upstream tag is moved. Pinning to an exact tag freezes the version actually in use and removes that drift.

## Mapping (before → after)

| Action | before | after |
|---|---|---|
| `actions/checkout` | `@v6` | `@v6.0.3` |
| `actions/setup-node` | `@v6` | `@v6.4.0` |
| `actions/create-github-app-token` | `@v3` | `@v3.2.0` |
| `actions/configure-pages` | `@v6` | `@v6.0.0` |
| `actions/upload-pages-artifact` | `@v5` | `@v5.0.0` |
| `actions/deploy-pages` | `@v5` | `@v5.0.0` |

Left as-is (already immutable):
- `miragon/pin-npm-dependencies@7bd516f… # v1.1.0` (full SHA)
- `amannn/action-semantic-pull-request@48f2562… # v6.1.1` (full SHA)
- `googleapis/release-please-action@45996ed… # v5.0.0` (full SHA)

## Notes

- No `@master` / `@main` / branch refs were present — all moving refs were major-only (`@vX`).
- `actions/checkout`'s latest release is `v7.0.0`, but it is intentionally pinned to the **latest v6.x.x (`v6.0.3`)** to avoid a blind major upgrade; bumping the major can be done separately and reviewed on its own.
- Tag-pinning protects against **major drift**. Full-SHA pinning (as already used for the three actions above) is the next stronger step and could be adopted repo-wide in a follow-up.

## Verification

- ✅ Grep confirms no moving refs remain.
- ✅ All three workflow files parse as valid YAML.
- ✅ `npm test` — 63 tests passed.
- ✅ `npm run build` — succeeded.