### PR TITLE
chore: adopt documented portless setup and add Conductor scripts

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,6 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "npm install"
+run = "npm run dev"
+run_mode = "concurrent"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,17 @@ This is a Slidev addon that enables displaying BPMN 2.0 diagrams in presentation
 ## Development Commands
 
 ```bash
-# Run the example presentation in dev mode (requires git and `npm install -g portless`)
-# Dev server URL is branch-based, e.g. http://slidev-addon-bpmn-main.localhost:1355
+# Run the example presentation in dev mode. portless ships as a devDependency, so a plain
+# `npm install` is enough — no global install. One-time per machine: start the proxy daemon
+# with `npx portless service install` (needs sudo once).
+# `dev` is just the portless proxy entrypoint; it runs the `dev:app` script (see
+# portless.json) and serves it on a stable .localhost URL. Portless is git-worktree-aware:
+# the main checkout is served at https://slidev-addon-bpmn.localhost, a linked worktree at
+# https://<worktree>.slidev-addon-bpmn.localhost — the slug is derived by portless, not built by us.
 npm run dev
+
+# Run the dev server directly, without portless (no stable URL, plain port)
+npm run dev:app
 
 # Build the example presentation
 npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vue/test-utils": "2.4.11",
         "jsdom": "29.1.1",
         "playwright-chromium": "1.61.0",
+        "portless": "0.15.0",
         "vitest": "4.1.9"
       },
       "engines": {
@@ -10418,6 +10419,24 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/portless": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/portless/-/portless-0.15.0.tgz",
+      "integrity": "sha512-GCrWz4GFPe4vbkGmDvXK78bGaKrVnIN2H6De3kAtoCfv1+CddaUaqPmA/hBzxQjGHbj+MpQMJEQ187tVqMtw2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "portless": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.15",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Display BPMN 2.0 diagrams in Slidev presentations",
   "type": "module",
   "scripts": {
-    "dev": "portless run sh -c 'npx slidev example.md --port $PORT --remote --bind 127.0.0.1 --open'",
+    "dev": "portless",
+    "dev:app": "slidev example.md --port $PORT --remote --bind 127.0.0.1 --open",
     "build": "slidev build example.md",
     "export": "slidev export example.md",
     "screenshot": "slidev export example.md --format png",
@@ -31,6 +32,7 @@
     "@vue/test-utils": "2.4.11",
     "jsdom": "29.1.1",
     "playwright-chromium": "1.61.0",
+    "portless": "0.15.0",
     "vitest": "4.1.9"
   },
   "keywords": [

--- a/portless.json
+++ b/portless.json
@@ -1,0 +1,4 @@
+{
+  "name": "slidev-addon-bpmn",
+  "script": "dev:app"
+}


### PR DESCRIPTION
## What & why

Align local dev with portless' documented best practices and wire it into Conductor. We were
not actually building the branch slug ourselves — portless already derives it via git-worktree
awareness — but the setup leaned on an inline `sh -c` wrapper, name inference and a global
install. This refactors to the documented pattern and adds Conductor scripts.

## Changes

- **Split the dev script**: `dev` is now just the portless proxy entrypoint; the real slidev
  command lives in `dev:app`. `$PORT` expands natively in the `dev:app` shell, so the
  `sh -c '…'` wrapper is gone. Non-portless users can run `npm run dev:app` directly.
- **Explicit `portless.json`** (`name` + `script: "dev:app"`) instead of relying on inference.
- **portless as a pinned devDependency** (`0.15.0`) so a plain `npm install` is enough — no
  `npm install -g portless`. The proxy daemon remains a one-time per-machine
  `npx portless service install` (needs sudo once).
- **`.conductor/settings.toml`**: `setup`/`run`/`run_mode` so each Conductor workspace gets its
  own git-worktree-aware `https://<workspace>.slidev-addon-bpmn.localhost` URL. `concurrent` is
  safe because every worktree gets a distinct portless subdomain.
- **Docs**: corrected CLAUDE.md (HTTPS `<worktree>.<project>.localhost` shape; slug is
  portless-derived, not hand-built; devDependency + one-time proxy setup).

## Notes

- portless only covers the TypeScript/JS dev server. No backend/Docker here, so nothing else
  needs per-workspace isolation.
- The published npm package is unaffected — `portless.json` and `.conductor/` are outside the
  `files` allowlist, and devDependencies are not shipped to consumers.

## Verification

- `npm run dev` resolves to portless without recursion (script override honored).
- `node_modules/.bin/portless --version` → `0.15.0`.
- `npm test` → 63/63 passing.
