### PR TITLE
docs: trim verbose portless comments in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,11 @@ This is a Slidev addon that enables displaying BPMN 2.0 diagrams in presentation
 ## Development Commands
 
 ```bash
-# Run the example presentation in dev mode. portless ships as a devDependency, so a plain
-# `npm install` is enough — no global install. One-time per machine: start the proxy daemon
-# with `npx portless service install` (needs sudo once).
-# `dev` is just the portless proxy entrypoint; it runs the `dev:app` script (see
-# portless.json) and serves it on a stable .localhost URL. Portless is git-worktree-aware:
-# the main checkout is served at https://slidev-addon-bpmn.localhost, a linked worktree at
-# https://<worktree>.slidev-addon-bpmn.localhost — the slug is derived by portless, not built by us.
+# Run the example deck through portless for a stable, git-worktree-aware .localhost URL.
+# One-time per machine: `npx portless service install` (needs sudo).
 npm run dev
 
-# Run the dev server directly, without portless (no stable URL, plain port)
+# Run the dev server directly, without portless (plain port, no stable URL)
 npm run dev:app
 
 # Build the example presentation


### PR DESCRIPTION
Follow-up to #68. The dev-commands block in CLAUDE.md grew to a 7-line comment; trim it to two concise lines matching the style of the surrounding command comments. Docs-only, no behavior change.