### PR TITLE
ci: pin first-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: actions/create-github-app-token@v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
@@ -44,10 +44,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -69,20 +69,20 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
       - run: npm ci
       - run: npm run build:pages
-      - uses: actions/configure-pages@v6.0.0
-      - uses: actions/upload-pages-artifact@v5.0.0
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist
       - id: deployment
-        uses: actions/deploy-pages@v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
   publish-dry-run:
     needs: release-please
@@ -92,8 +92,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## What

Pin all first-party `actions/*` references to full-length commit SHAs, keeping the human-readable version as a trailing comment.

| File | Action | Before | After |
|---|---|---|---|
| build.yml, release-please.yml | `actions/checkout` | `@v6.0.3` | `@df4cb1c…` # v6.0.3 |
| build.yml, release-please.yml | `actions/setup-node` | `@v6.4.0` | `@48b55a0…` # v6.4.0 |
| release-please.yml | `actions/create-github-app-token` | `@v3.2.0` | `@bcd2ba4…` # v3.2.0 |
| release-please.yml | `actions/configure-pages` | `@v6.0.0` | `@45bfe01…` # v6.0.0 |
| release-please.yml | `actions/upload-pages-artifact` | `@v5.0.0` | `@fc324d3…` # v5.0.0 |
| release-please.yml | `actions/deploy-pages` | `@v5.0.0` | `@cd2ce8f…` # v5.0.0 |

## Why

Mutable version tags (`@vX.Y.Z`) can be silently repointed by whoever controls the upstream repo — exactly how the [`tj-actions/changed-files` compromise (CVE-2025-30066)](https://github.com/tj-actions/changed-files/security/advisories) dumped CI secrets; only SHA-pinned consumers were unaffected. SHA pinning is the [GitHub-recommended hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and the OpenSSF Scorecard `Pinned-Dependencies` check.

## Scope

- The three third-party actions (`amannn/action-semantic-pull-request`, `googleapis/release-please-action`, `miragon/pin-npm-dependencies`) were **already** SHA-pinned with version comments — left untouched.
- After this change: **15 references · 15 pinned · 0 unpinned.**
- `.github/dependabot.yml` already enables the `github-actions` ecosystem, so these SHA pins and their version comments stay current automatically.