### PR TITLE
chore: switch dependabot to balanced grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,43 +1,44 @@
 version: 2
 updates:
-  # Config for npm dependencies
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown:
-      default-days: 5
     labels:
       - "dependencies"
-    assignees:
-      - "emaarco"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 3
     groups:
-      dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-          - "minor"
-          - "major"
-    open-pull-requests-limit: 2
+      npm-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
 
-  # Config for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 5
     labels:
       - "dependencies"
-    assignees:
-      - "emaarco"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 5
     groups:
       github-actions:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-          - "minor"
-          - "major"
-    open-pull-requests-limit: 2
+        applies-to: version-updates
+        patterns: ["*"]
+      github-actions-security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
## What

Switches `.github/dependabot.yml` from low-noise grouping to **balanced** mode, better suited to a published open-source npm package where breaking changes deserve individual review.

## Changes

- **Majors split out**: minor+patch stay grouped per ecosystem, each **major** now opens its own PR for individual review (previously all types were bundled into one group).
- **Dropped per-block `assignees`**: `.github/CODEOWNERS` (`* @emaarco`) already requests review on every PR, so the duplicate wiring is removed.
- **`open-pull-requests-limit` 2 → 10** (npm): gives headroom now that majors arrive individually.
- **Security groups added** (`applies-to: security-updates`): groups CVE PRs per ecosystem instead of one-per-vulnerability. Security updates remain unaffected by cadence/cooldown.
- **Tiered npm cooldown** (major 14 / minor 5 / patch 3 days): fresh majors mature longer before a PR opens (supply-chain guard).
- **Explicit `commit-message`** (`chore` + `include: scope`): makes the existing `chore(deps):` convention explicit.

## Kept as-is

- Cadence: npm **weekly**, github-actions **monthly** (PR history shows this works — 21 merged / 1 closed, no rot).
- github-actions fully grouped incl. majors (every `uses:` is SHA-pinned, CI gates merges, bumps are mechanical).
- `dependencies` label.

## Verification

- Pin gate passed with no fixes: npm is `save-exact` + committed lockfile + CI-enforced (`miragon/pin-npm-dependencies`); all actions SHA-pinned.
- YAML validated; CODEOWNERS reports no errors.