### PR TITLE
feat(bpmn): fill available space for small diagrams via configurable maxScale

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Renders interactive BPMN diagrams with token simulation capabilities. Perfect fo
 | `bpmnFilePath` | `string` | *required* | Path to the `.bpmn` file (relative to `public/`) |
 | `width` | `string` | `'100%'` | Width of the diagram container |
 | `height` | `string` | `'auto'` | Height of the diagram container (defaults to 500px when 'auto') |
+| `maxScale` | `number` | `2` | Cap on how far a small diagram is enlarged past its native size. Lower keeps it smaller; higher lets it fill more. |
 
 The token simulation provides interactive controls for stepping through process execution with animated token flow.
 
@@ -135,6 +136,7 @@ In fullscreen mode, the panel can be hidden and shown again via the toolbar — 
 | `width` | `string` | `'100%'` | Width of the modeler container |
 | `height` | `string` | `'500px'` | Height of the modeler container |
 | `engine` | `'zeebe' \| 'camunda7'` | — | Optional engine. Mounts a `bpmn-js-properties-panel` configured for the chosen engine. Omit for a panel-less modeler. |
+| `maxScale` | `number` | `2` | Cap on how far a small diagram is enlarged past its native size (e.g. a lone start event on a blank canvas). Lower keeps it smaller; higher lets it fill more. |
 
 ## 💡 Tips
 

--- a/components/BpmnModeler.vue
+++ b/components/BpmnModeler.vue
@@ -4,8 +4,8 @@
     <p v-if="error" class="text-red-500">{{ error }}</p>
 
     <div ref="viewerContainerRef" class="bpmn-modeler-container" :style="{
-      width: `calc(${props.width} - ${margin * 2}px)`,
-      height: `calc(${containerHeight} - ${margin * 2}px)`,
+      width: `calc(100% - ${margin * 2}px)`,
+      height: `calc(100% - ${margin * 2}px)`,
       margin: `${margin}px`,
     }"></div>
 
@@ -136,6 +136,7 @@ const props = withDefaults(defineProps<{
   width?: string
   height?: string
   engine?: Engine
+  maxScale?: number
 }>(), {
   width: '100%',
   height: '500px',
@@ -148,6 +149,12 @@ function resolveEngineConfig() {
 }
 
 const containerHeight = props.height
+
+// User-overridable enlarge cap for fitDiagram; undefined → fitDiagram's default.
+function resolveMaxScale(): number | undefined {
+  const n = Number(props.maxScale)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
 
 async function waitForContainer(containerRef: Ref<HTMLDivElement | null>): Promise<boolean> {
   return new Promise((resolve) => {
@@ -192,7 +199,7 @@ async function renderViewer(): Promise<boolean> {
     await viewer.importXML(currentXml.value)
     const canvas = viewer.get('canvas') as any
     canvas.resized()
-    fitDiagram(canvas)
+    fitDiagram(canvas, undefined, resolveMaxScale())
   }
   return true
 }
@@ -236,7 +243,7 @@ async function openFullscreen() {
   eventBus.on('commandStack.changed', () => { hasModelerChanges = true })
   const canvas = modeler.get('canvas') as any
   canvas.resized()
-  fitDiagram(canvas)
+  fitDiagram(canvas, undefined, resolveMaxScale())
 
   if (props.engine === 'camunda7') {
     const transactionBoundaries = modeler.get('transactionBoundaries') as any

--- a/components/BpmnTokenSimulation.vue
+++ b/components/BpmnTokenSimulation.vue
@@ -3,8 +3,8 @@
     <p v-if="loading">Loading BPMN diagram...</p>
     <p v-if="error" class="text-red-500">{{ error }}</p>
     <div ref="containerRef" class="bpmn-token-simulation-container" :style="{
-    width: `calc(${props.width} - ${margin * 2}px)`,
-    height: `calc(${containerHeight} - ${margin * 2}px)`,
+    width: `calc(100% - ${margin * 2}px)`,
+    height: `calc(100% - ${margin * 2}px)`,
     margin: `${margin}px`,
   }"
     ></div>
@@ -98,6 +98,7 @@ const props = withDefaults(defineProps<{
   width?: string
   height?: string
   fullscreen?: boolean
+  maxScale?: number
 }>(), {
   width: '100%',
   height: 'auto',
@@ -105,6 +106,12 @@ const props = withDefaults(defineProps<{
 })
 
 const containerHeight = props.height === 'auto' ? '500px' : props.height
+
+// User-overridable enlarge cap for fitDiagram; undefined → fitDiagram's default.
+function resolveMaxScale(): number | undefined {
+  const n = Number(props.maxScale)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
 
 /**
  * Polls for container dimensions to be ready before rendering.
@@ -154,7 +161,7 @@ async function renderBpmn() {
 
     const canvas = viewer.get('canvas') as any
     canvas.resized()
-    fitDiagram(canvas)
+    fitDiagram(canvas, undefined, resolveMaxScale())
 
     observeContainerForToggleScale()
   })
@@ -182,7 +189,7 @@ async function openFullscreen() {
   await fullscreenViewer.importXML(currentXml.value)
   const canvas = fullscreenViewer.get('canvas') as any
   canvas.resized()
-  fitDiagram(canvas)
+  fitDiagram(canvas, undefined, resolveMaxScale())
 }
 
 function closeFullscreen() {

--- a/example.md
+++ b/example.md
@@ -75,6 +75,14 @@ Für die Camunda-7-Fraktion: `engine="camunda7"` swaps in the Camunda Platform p
 
 ## Blank Canvas Modeler
 
-No `engine` prop? Dann gibt's nur die Zeichenfläche – a bare modeler for pure structural modeling. Ideal for live sessions where you build a process from scratch with your audience.
+No `engine` prop? Dann gibt's nur die Zeichenfläche für live modeling from scratch. Und weil so a Blank Canvas anfangs nur a einzigs Element hat, kannst mit `:max-scale` de Zoom-Grenz selba festlegn – standardmäßig 2, do auf 1.5 gsetzt.
 
-<BpmnModeler height="320px"></BpmnModeler>
+<BpmnModeler :max-scale="1.5" height="320px"></BpmnModeler>
+
+---
+
+## Small Diagrams Fill the Space
+
+Sauba! A kloans Modell duad si jetz aa breit macha, statt mickrig in da Mittn zu hocka – de kompaktn Diagramm wachsn schee mit, a wahre Mordsgaudi fürs Aug!
+
+<BpmnTokenSimulation bpmnFilePath="./loan-approval.bpmn" width="90%" height="360px"></BpmnTokenSimulation>

--- a/internal/fitDiagram.ts
+++ b/internal/fitDiagram.ts
@@ -1,15 +1,16 @@
-// Centre the diagram in the canvas with a relative pad on every side.
-// Pad is computed against the diagram's own larger dimension so the visual
-// margin stays proportional regardless of card size.
+// Centre the diagram with a pad on every side, proportional to its larger dimension.
 const DIAGRAM_PADDING_RATIO = 0.05
 
-// Never enlarge a diagram beyond its native pixel size — image-viewer rule.
-// Without this, a near-empty diagram (e.g. a single start event) balloons to
-// fill the card and looks absurd.
-const MAX_SCALE = 1
+// Default cap on how far a diagram may be enlarged past its native pixel size.
+// Overridable per call (surfaced as a component prop) via fitDiagram's maxScale arg.
+export const DEFAULT_MAX_SCALE = 2
 
 // canvas: bpmn-js Canvas service (typed loosely to mirror existing call-sites).
-export function fitDiagram(canvas: any, ratio: number = DIAGRAM_PADDING_RATIO): void {
+export function fitDiagram(
+  canvas: any,
+  ratio: number = DIAGRAM_PADDING_RATIO,
+  maxScale: number = DEFAULT_MAX_SCALE,
+): void {
   const view = canvas.viewbox()
   const inner = view?.inner
   const outer = view?.outer
@@ -23,24 +24,21 @@ export function fitDiagram(canvas: any, ratio: number = DIAGRAM_PADDING_RATIO): 
   let width = inner.width + pad * 2
   let height = inner.height + pad * 2
 
-  // 2. If fitting would enlarge beyond MAX_SCALE, clamp at native and centre
-  // on the diagram's bbox centre.
+  // 2. If fitting would enlarge past maxScale, clamp there, centred on the bbox.
   const fitScale = Math.min(outer.width / width, outer.height / height)
-  if (fitScale > MAX_SCALE) {
+  if (fitScale > maxScale) {
     const cx = inner.x + inner.width / 2
     const cy = inner.y + inner.height / 2
     canvas.viewbox({
-      x: cx - outer.width / (2 * MAX_SCALE),
-      y: cy - outer.height / (2 * MAX_SCALE),
-      width: outer.width / MAX_SCALE,
-      height: outer.height / MAX_SCALE,
+      x: cx - outer.width / (2 * maxScale),
+      y: cy - outer.height / (2 * maxScale),
+      width: outer.width / maxScale,
+      height: outer.height / maxScale,
     })
     return
   }
 
-  // 3. Expand the slacker axis so the box matches the outer aspect ratio.
-  // bpmn-js fits with min-scale and anchors the box's top-left at the canvas
-  // origin, which would otherwise leave the slack on one side only.
+  // 3. Expand the slacker axis to the outer aspect (bpmn-js otherwise anchors slack top-left).
   const outerAspect = outer.width / outer.height
   const boxAspect = width / height
   if (boxAspect < outerAspect) {

--- a/tests/components/BpmnTokenSimulation.test.ts
+++ b/tests/components/BpmnTokenSimulation.test.ts
@@ -111,6 +111,20 @@ describe('BpmnTokenSimulation.vue', () => {
     expect(outerDiv.style.height).toBe('700px')
   })
 
+  it('sizes the root to the width prop while the inner container fills it', () => {
+    mockFetchSuccess()
+    const wrapper = mount(BpmnTokenSimulation, {
+      props: { bpmnFilePath: 'test.bpmn', width: '90%' },
+    })
+    const rootDiv = wrapper.find('div').element as HTMLDivElement
+    const innerDiv = wrapper.find('div[style*="calc"]').element as HTMLDivElement
+    // The root carries the actual width; the inner container fills it (100% - margins)
+    // instead of re-applying the % — which used to shrink a 90% viewer to ~81% and centre it.
+    expect(rootDiv.style.width).toBe('90%')
+    expect(innerDiv.style.width).toBe('calc(100% - 10px)')
+    expect(innerDiv.style.height).toBe('calc(100% - 10px)')
+  })
+
   it('renders successfully when container has dimensions', async () => {
     mockFetchSuccess()
     const wrapper = mount(BpmnTokenSimulation, { props: { bpmnFilePath: 'test.bpmn' } })

--- a/tests/internal/fitDiagram.test.ts
+++ b/tests/internal/fitDiagram.test.ts
@@ -31,7 +31,7 @@ describe('fitDiagram', () => {
   })
 
   it('expands width to match a wider outer container, keeping the diagram centred', () => {
-    // Inner is large enough that fitting does not trigger the MAX_SCALE clamp.
+    // Inner is large enough that fitting does not trigger the clamp.
     const canvas = createCanvas(
       { x: 0, y: 0, width: 2000, height: 1000 },
       { width: 1000, height: 500 },
@@ -70,9 +70,8 @@ describe('fitDiagram', () => {
     })
   })
 
-  it('clamps a tiny diagram at native scale and centres it (no enlargement past 1×)', () => {
-    // A 36×36 start event in a 1500×500 card. Padded fit would scale ~12×;
-    // we want the box to span the full outer (scale = 1) centred on the bbox.
+  it('clamps a tiny diagram at the default cap (2×) and centres it, instead of ballooning to fit', () => {
+    // 36×36 in a 1500×500 card: padded fit ≈12×, capped at 2× native (~72px, not huge).
     const canvas = createCanvas(
       { x: 100, y: 100, width: 36, height: 36 },
       { width: 1500, height: 500 },
@@ -80,14 +79,55 @@ describe('fitDiagram', () => {
 
     fitDiagram(canvas)
 
-    // bbox centre (118, 118) → box origin = (118 - 750, 118 - 250) = (-632, -132).
-    // Box dims = outer dims (scale = 1).
+    // bbox centre (118,118); box = outer/2 = 750×250, origin (-257, -7).
+    expect(canvas._setter).toHaveBeenLastCalledWith({
+      x: -257,
+      y: -7,
+      width: 750,
+      height: 250,
+    })
+  })
+
+  it('honours an explicit maxScale argument (clamps at the given cap)', () => {
+    // Same 36×36 in a 1500×500 card, but maxScale=1 → clamp at native (viewbox = outer).
+    const canvas = createCanvas(
+      { x: 100, y: 100, width: 36, height: 36 },
+      { width: 1500, height: 500 },
+    )
+
+    fitDiagram(canvas, undefined, 1)
+
+    // bbox centre (118,118); box = outer/1 = 1500×500, origin (-632, -132).
     expect(canvas._setter).toHaveBeenLastCalledWith({
       x: -632,
       y: -132,
       width: 1500,
       height: 500,
     })
+  })
+
+  it('enlarges a small-but-real diagram to fill the card (up to the cap)', () => {
+    // Regression guard: a 560×224 process smaller than its 1000×500 pane must scale UP
+    // to fill it — old MAX_SCALE=1 clamped to native 1× (width 1000); the 2× cap lets ~1.62 apply.
+    const canvas = createCanvas(
+      { x: 0, y: 0, width: 560, height: 224 },
+      { width: 1000, height: 500 },
+    )
+
+    fitDiagram(canvas)
+
+    // pad=28 → box 616×280. fitScale min(1.62, 1.79)=1.62 (<2, no clamp).
+    // boxAspect 2.2 > outerAspect 2 → expand height to 616/2=308, y=-28-14=-42.
+    expect(canvas._setter).toHaveBeenLastCalledWith({
+      x: -28,
+      y: -42,
+      width: 616,
+      height: 308,
+    })
+
+    // Genuinely enlarged: viewbox width 616 < outer 1000 → zoom ~1.62×, not native 1×.
+    const [box] = canvas._setter.mock.calls.at(-1) as [Box]
+    expect(box.width).toBeLessThan(1000)
   })
 
   it('honours an explicit ratio', () => {


### PR DESCRIPTION
## Summary

Small BPMN diagrams (fewer/smaller elements than their card) rendered at native 1× and sat tiny in a large pane. This makes them **fill the available card**, while keeping a cap so a near-empty diagram (e.g. a lone start event) can't balloon to fill everything. The cap is now a configurable `maxScale` prop.

## Changes

- **feat:** `maxScale` prop on `BpmnTokenSimulation` and `BpmnModeler` — overrides the enlarge cap per usage (default `2`). Invalid values (`0`, negative, non-numeric) fall back to the default. `fitDiagram` takes an optional `maxScale` arg backed by the exported `DEFAULT_MAX_SCALE`.
- **fix:** the inner render container re-applied the `width` prop inside its own `calc()`, so a `width="90%"` viewer ended up ~81% wide and appeared centred/indented. It now fills its root (`calc(100% - …)`), so non-full-width viewers size correctly and left-align. Default `100%` usages are byte-identical (no regression).
- **docs:** documented `maxScale` in both prop tables; the example deck demonstrates it on the blank-canvas modeler.
- **test:** regression tests for the fill behaviour, the `maxScale` override, and the container-sizing fix.

## Testing

- `npm run test` → **66/66 passing**.
- Verified in the running deck (headless Chromium): a small diagram fills its card (~1.6×), large diagrams still scale down unchanged, the blank modeler honours `:max-scale`, and non-full-width viewers left-align and fit within the slide.

## Review

Reviewed via subagent — **0 criticals**. The flagged findings (example caption/value mismatch, missing README docs, `maxScale` input guard, and a layout regression test) are all addressed here.
