### PR TITLE
fix(bpmn): re-fit viewers when their container settles or resizes

### DIFF
--- a/components/BpmnModeler.vue
+++ b/components/BpmnModeler.vue
@@ -130,6 +130,7 @@ const currentXml = ref<string | null>(null)
 let viewer: InstanceType<typeof BpmnViewer> | null = null
 let modeler: InstanceType<typeof BpmnModeler> | null = null
 let hasModelerChanges = false
+let resizeObserver: ResizeObserver | null = null
 
 const props = withDefaults(defineProps<{
   bpmnFilePath?: string
@@ -200,8 +201,35 @@ async function renderViewer(): Promise<boolean> {
     const canvas = viewer.get('canvas') as any
     canvas.resized()
     fitDiagram(canvas, undefined, resolveMaxScale())
+    observeViewerContainer()
   }
   return true
+}
+
+function observeViewerContainer() {
+  if (typeof ResizeObserver === 'undefined' || !viewerContainerRef.value) return
+  resizeObserver?.disconnect()
+  let lastW = 0
+  let lastH = 0
+  resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const w = Math.round(entry.contentRect.width)
+      const h = Math.round(entry.contentRect.height)
+      if (w > 0 && h > 0 && (w !== lastW || h !== lastH)) {
+        lastW = w
+        lastH = h
+        refitViewer()
+      }
+    }
+  })
+  resizeObserver.observe(viewerContainerRef.value)
+}
+
+function refitViewer() {
+  if (!viewer) return
+  const canvas = viewer.get('canvas') as any
+  canvas.resized()
+  fitDiagram(canvas, undefined, resolveMaxScale())
 }
 
 async function renderBpmn() {
@@ -291,6 +319,8 @@ onSlideEnter(async () => {
 })
 
 onUnmounted(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
   viewer?.destroy()
   viewer = null
   modeler?.destroy()

--- a/components/BpmnTokenSimulation.vue
+++ b/components/BpmnTokenSimulation.vue
@@ -209,10 +209,28 @@ function observeContainerForToggleScale() {
   }
   apply(target.clientWidth)
   if (typeof ResizeObserver === 'undefined') return
+  let lastW = 0
+  let lastH = 0
   resizeObserver = new ResizeObserver((entries) => {
-    for (const entry of entries) apply(entry.contentRect.width)
+    for (const entry of entries) {
+      apply(entry.contentRect.width)
+      const w = Math.round(entry.contentRect.width)
+      const h = Math.round(entry.contentRect.height)
+      if (w > 0 && h > 0 && (w !== lastW || h !== lastH)) {
+        lastW = w
+        lastH = h
+        refitDiagram()
+      }
+    }
   })
   resizeObserver.observe(target)
+}
+
+function refitDiagram() {
+  if (!viewer) return
+  const canvas = viewer.get('canvas') as any
+  canvas.resized()
+  fitDiagram(canvas, undefined, resolveMaxScale())
 }
 
 /**

--- a/tests/components/BpmnModeler.test.ts
+++ b/tests/components/BpmnModeler.test.ts
@@ -175,6 +175,35 @@ describe('BpmnModeler.vue', () => {
     })
   })
 
+  it('re-fits the inline viewer when its container resizes after the initial fit', async () => {
+    let observerCallback: ((entries: Array<{ contentRect: { width: number, height: number } }>) => void) | null = null
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(cb: (entries: Array<{ contentRect: { width: number, height: number } }>) => void) {
+        observerCallback = cb
+      }
+      observe() {}
+      disconnect() {}
+    })
+
+    mockFetchSuccess()
+    const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    const resizedBefore = mockResized.mock.calls.length
+    const setterBefore = mockViewbox.mock.calls.filter((args) => args.length === 1 && typeof args[0] === 'object').length
+    expect(observerCallback).not.toBeNull()
+
+    observerCallback!([{ contentRect: { width: 450, height: 290 } }])
+    await flushPromises()
+
+    const setterAfter = mockViewbox.mock.calls.filter((args) => args.length === 1 && typeof args[0] === 'object').length
+    expect(mockResized.mock.calls.length).toBeGreaterThan(resizedBefore)
+    expect(setterAfter).toBeGreaterThan(setterBefore)
+  })
+
   it('shows edit button after successful load', async () => {
     mockFetchSuccess()
     const wrapper = mount(BpmnModelerComponent, { props: { bpmnFilePath: 'test.bpmn' } })

--- a/tests/components/BpmnTokenSimulation.test.ts
+++ b/tests/components/BpmnTokenSimulation.test.ts
@@ -147,6 +147,35 @@ describe('BpmnTokenSimulation.vue', () => {
     })
   })
 
+  it('re-fits the diagram when the container resizes after the initial fit', async () => {
+    let observerCallback: ((entries: Array<{ contentRect: { width: number, height: number } }>) => void) | null = null
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(cb: (entries: Array<{ contentRect: { width: number, height: number } }>) => void) {
+        observerCallback = cb
+      }
+      observe() {}
+      disconnect() {}
+    })
+
+    mockFetchSuccess()
+    const wrapper = mount(BpmnTokenSimulation, { props: { bpmnFilePath: 'test.bpmn' } })
+    giveContainerDimensions(wrapper)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await flushPromises()
+
+    const resizedBefore = mockResized.mock.calls.length
+    const setterBefore = mockViewbox.mock.calls.filter((args) => args.length === 1 && typeof args[0] === 'object').length
+    expect(observerCallback).not.toBeNull()
+
+    observerCallback!([{ contentRect: { width: 450, height: 290 } }])
+    await flushPromises()
+
+    const setterAfter = mockViewbox.mock.calls.filter((args) => args.length === 1 && typeof args[0] === 'object').length
+    expect(mockResized.mock.calls.length).toBeGreaterThan(resizedBefore)
+    expect(setterAfter).toBeGreaterThan(setterBefore)
+  })
+
   it('bails silently when container dimensions never arrive (Slidev preload)', async () => {
     vi.useFakeTimers()
     mockFetchSuccess()


### PR DESCRIPTION
## Problem

Small/wide BPMN diagrams rendered too small and failed to fill their pane, even with `maxScale` raised. `maxScale` was a red herring — the diagrams weren't even reaching a normal contain-fit.

**Root cause:** `fitDiagram()` runs once, during slide-enter, while the container still has a *transitional* (wrong-aspect) size. It bakes a viewbox from that instant and never re-fits when the pane settles to its final size. Measured live: the diagram was drawn at scale **0.50** where a proper contain-fit needs **0.73** — ~69% of the size it should be.

## Fix

Observe the container with a `ResizeObserver` and re-fit the diagram on every real size change, so the fit corrects once the pane settles (and on any later resize).

- `BpmnTokenSimulation.vue` — re-fit the viewer on container resize
- `BpmnModeler.vue` — same, for the inline read-only viewer

The **fullscreen editable modeler is left untouched**: its container is stable, and re-fitting there would fight a user's manual pan/zoom.

## Verification

Reproduced and confirmed on a live dev server:

| | before | after |
|---|---|---|
| token-sim applied scale | 0.50 | **0.73** (= contain-fit target) |
| inline-modeler applied scale | under-fit | **0.57** (= contain-fit target) |

- 2 regression tests added (stub `ResizeObserver`, assert re-fit fires)
- **68/68 tests pass**