### PR TITLE
ci: add standalone reusable Deploy Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,52 @@
+name: Deploy Pages
+
+# Builds the example deck and publishes it to GitHub Pages.
+# Triggerable two ways:
+#   - workflow_dispatch: deploy on demand from the Actions tab (no release needed)
+#   - workflow_call:      reused by the Release workflow after a release is cut
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build and deploy (blank = the ref this run was started from)"
+        type: string
+        required: false
+        default: ""
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to build and deploy"
+        type: string
+        required: false
+        default: ""
+
+# Needed for the GitHub Pages deployment via OIDC.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: true
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+      - run: npm ci
+      - run: npm run build:pages
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: dist
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,32 +57,13 @@ jobs:
   deploy-pages:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' && inputs.dry_run != true }}
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write
       id-token: write
-    concurrency:
-      group: pages
-      cancel-in-progress: true
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
-      - run: npm ci
-      - run: npm run build:pages
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: dist
-      - id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+    uses: ./.github/workflows/pages.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}
 
   publish-dry-run:
     needs: release-please


### PR DESCRIPTION
## Why

Publishing the demo deck to GitHub Pages was welded to `release-please.yml` and only ran when a release was cut (`release_created == true`). That makes it impossible to redeploy the Pages site without going through a full release — which we need, e.g. after a fix that only affects the deployed deck (see #79).

## What

- New `.github/workflows/pages.yml` — builds `npm run build:pages` and deploys to GitHub Pages. Triggerable two ways:
  - **`workflow_dispatch`** — deploy on demand from the Actions tab (optional `ref` input; blank = the ref the run was started from). No release required.
  - **`workflow_call`** — reused by the Release workflow.
- `release-please.yml` `deploy-pages` job now **calls** the reusable workflow (`uses: ./.github/workflows/pages.yml` with `ref: <tag>`) instead of duplicating the checkout/build/deploy steps.

Behaviour on release is unchanged; the deploy logic just lives in one place now and is independently runnable.

Pinned action SHAs and the `github-pages` environment / `concurrency: pages` are preserved. `actionlint` passes on both files.

## Follow-up

After merge, the Pages site can be refreshed any time via **Actions → Deploy Pages → Run workflow** (from `main`).